### PR TITLE
Fix Dockerfile sample JAR copy path for Koyeb build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENV PORT=6006
 ENV SPRING_PROFILES_ACTIVE=koyeb
 EXPOSE 6006
 
-COPY --from=build /app/sample/target/thymeleaflet-sample-0.1.0-SNAPSHOT.jar /app/app.jar
+COPY --from=build /app/sample/target/thymeleaflet-sample-*.jar /app/app.jar
 
 CMD ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## Summary
- Fix Dockerfile sample JAR copy path to avoid hard-coded version
- Use wildcard copy so Koyeb build works after version bumps

## Testing
- mvn -f sample/pom.xml -DskipTests package
