### PR TITLE
Docs: パーサ仕様・互換性・制約の明文化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 
 ## [Unreleased]
 
-- TBD
+- Parser migration progress:
+- Define parser baseline/spec documents for Thymeleaf 3.1.2 compatibility scope.
+- Introduce dedicated fragment signature parser and switch to Thymeleaf internal signature parsing.
+- Add structured signature diagnostics (code/severity/user-safe message) and surface in UI.
+- Remove legacy plain-name fallback for invalid fragment signatures.
+- Align Story Values ordering/status display with JavaDoc-driven parameter ordering and state chips.
 
 ## [0.2.2] - 2026-02-07
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -138,6 +138,24 @@ thymeleaflet:
 -->
 ```
 
+## フラグメントシグネチャ解析ポリシー
+
+- 基準: Thymeleaf `3.1.2.RELEASE`
+- 参照パーサ: `org.thymeleaf.standard.expression.FragmentSignatureUtils`
+- v1 では、UIで安定サポートする範囲を Thymeleaf の受理範囲より狭く定義しています。
+
+現時点での安定サポート:
+
+- `th:fragment="name"`
+- `th:fragment="name()"`
+- `th:fragment="name(param1, param2)"`
+
+補足:
+
+- 非対応のシグネチャは発見対象からスキップし、診断情報を出力します。
+- 診断は code/severity をログ出力し、UIには安全なメッセージのみ表示します。
+- 詳細は `docs/parser-spec.ja.md` / `docs/parser-model.ja.md` を参照してください。
+
 ## ローカルビルド
 
 ```bash
@@ -156,6 +174,8 @@ npm run build
 - [docs/javadoc.ja.md](docs/javadoc.ja.md)
 - [docs/stories.ja.md](docs/stories.ja.md)
 - [docs/security.ja.md](docs/security.ja.md)
+- [docs/parser-spec.ja.md](docs/parser-spec.ja.md)
+- [docs/parser-model.ja.md](docs/parser-model.ja.md)
 
 ## コントリビューション
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ Thymeleaflet parses JavaDoc-style comments embedded in HTML templates. Example:
 -->
 ```
 
+## Fragment Signature Parsing Policy
+
+- Baseline: Thymeleaf `3.1.2.RELEASE`
+- Reference parser: `org.thymeleaf.standard.expression.FragmentSignatureUtils`
+- v1 UI support set is intentionally narrower than Thymeleaf parse compatibility.
+
+Current stable UI support:
+
+- `th:fragment="name"`
+- `th:fragment="name()"`
+- `th:fragment="name(param1, param2)"`
+
+Notes:
+
+- Unsupported signature styles are skipped from discovery and reported via diagnostics.
+- Diagnostics are logged with code/severity and surfaced to the UI as user-safe messages.
+- See detailed rules: `docs/parser-spec.md` and `docs/parser-model.md`.
+
 ## Build from Source
 
 ```bash
@@ -161,6 +179,8 @@ See:
 - [docs/javadoc.md](docs/javadoc.md)
 - [docs/stories.md](docs/stories.md)
 - [docs/security.md](docs/security.md)
+- [docs/parser-spec.md](docs/parser-spec.md)
+- [docs/parser-model.md](docs/parser-model.md)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add parser compatibility and constraint section to `README.md` and `README.ja.md`
- document Thymeleaf 3.1.2 baseline and v1 UI support subset explicitly
- add parser-spec/parser-model links to README doc indexes
- add parser migration summary to `CHANGELOG.md` unreleased section

## Testing
- `mvn test`
- `npm run test:e2e`

Closes #55
