### PR TITLE
Docs: 宣言側シグネチャ仕様の文言を明確化

### DIFF
--- a/docs/parser-spec.ja.md
+++ b/docs/parser-spec.ja.md
@@ -96,15 +96,9 @@ ws             = { " " | "\t" | "\n" | "\r" } ;
 | ` profileCard ( name , age ) ` | name=`profileCard`, params=`[name, age]` |
 | `profileCard(name,,age)` | `INVALID_SIGNATURE` |
 | `profileCard(name` | `INVALID_SIGNATURE` |
-| `profileCard(name='x')` | Thymeleaf内部挙動次第で受理可能性はあるが、v1 UIサポートでは `UNSUPPORTED_SYNTAX` |
+| `profileCard(name='x')` | `th:fragment` の宣言側構文としては非対応のため `UNSUPPORTED_SYNTAX` |
 
-## 9. 互換性ポリシー
-
-- 単純シグネチャは既存互換とする。
-- これまで曖昧に通っていた文字列は、明示的エラーになる場合がある。
-- 一部失敗しても、一覧全体が壊れないよう UI へ診断を渡す。
-
-## 10. 実装Issue向けテスト要件
+## 9. 実装Issue向けテスト要件
 
 - 受理/拒否ケースの単体テスト
 - 正規化順序のゴールデンテスト

--- a/docs/parser-spec.md
+++ b/docs/parser-spec.md
@@ -75,6 +75,7 @@ The parser does **not** support these declaration forms in v1:
 - Fragment selector forms beyond identifier name (e.g. CSS selector style fragment names).
 - Parameter default expression syntax inside declaration.
 - Parameter assignment syntax inside declaration.
+- Assignment style arguments (e.g. `name='x'`) are for fragment call sites, not declaration signatures.
 - Nested parenthesis or expression parsing inside parameter tokens.
 - Non-identifier parameter tokens.
 
@@ -101,15 +102,9 @@ When unsupported syntax is detected, parser behavior:
 | ` profileCard ( name , age ) ` | name=`profileCard`, params=`[name, age]` |
 | `profileCard(name,,age)` | error `INVALID_SIGNATURE` |
 | `profileCard(name` | error `INVALID_SIGNATURE` |
-| `profileCard(name='x')` | parse-compatible may vary by Thymeleaf internals, but v1 UI support: `UNSUPPORTED_SYNTAX` |
+| `profileCard(name='x')` | declaration-side syntax is unsupported in `th:fragment`; handled as `UNSUPPORTED_SYNTAX` |
 
-## 9. Compatibility Policy
-
-- Existing simple signatures remain compatible.
-- Currently accepted-but-ambiguous strings may become explicit errors with diagnostics.
-- UI should surface warnings/errors without failing the full fragment list.
-
-## 10. Test Requirements (for implementation issues)
+## 9. Test Requirements (for implementation issues)
 
 - Unit tests for grammar acceptance/rejection.
 - Golden tests for normalization output ordering.


### PR DESCRIPTION
## Summary
- clarify that `profileCard(name='x')` is not declaration-side (`th:fragment`) syntax
- remove ambiguous wording about Thymeleaf internal acceptance possibility
- remove compatibility policy section from parser spec docs (EN/JA)

## Files
- `docs/parser-spec.md`
- `docs/parser-spec.ja.md`
