### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.5] - 2026-02-08
+
+- Fixed
+  - Aligned source-build and demo image Java requirements to avoid deployment build failures on Error Prone/NullAway-enabled compilation.
+  - Resolved `ResolvedStorybookConfig` nullable nested-config handling issues flagged by NullAway.
+- Refactored
+  - Introduced and applied architecture boundary tests (ArchUnit) for ports, domain purity, and configuration-boundary usage.
+  - Reduced direct infrastructure coupling in application services by introducing fragment catalog abstraction where effective.
+  - Balanced architecture strictness with developer experience by avoiding over-abstraction in UI model coordination paths.
+- Test
+  - Added integration coverage for story-parameter retrieval behavior to protect refactoring safety.
+- Docs
+  - Added `ARCHITECTURE.md` to explicitly document currently enforced architecture rules and operational policy.
+  - Updated `AGENTS.md` with release guardrails (release branch flow, release checklist, and Java build/runtime notes).
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.5`.
+
+### Issues
+
+- #73 ArchUnit設計制約の追加と運用ポリシー整備
+
 ## [0.2.4] - 2026-02-08
 
 - Changed

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.4</version>
+            <version>0.2.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump version to `0.2.5` in `pom.xml`
- bump sample app version/dependency to `0.2.5` in `sample/pom.xml`
- update `CHANGELOG.md` with `0.2.5` release notes

## Testing
- `mvn test -q`
- `npm run test:e2e`

Closes #73
