### PR TITLE
refactor: base-path single source + constructor injection (cmd_20260209_013)

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -120,16 +120,20 @@ public class StorybookAutoConfiguration {
      */
     @Bean
     @Order(0) // 最高優先度
-    public WebMvcConfigurer thymeleafletResourceConfigurer() {
+    public WebMvcConfigurer thymeleafletResourceConfigurer(ResolvedStorybookConfig resolvedStorybookConfig) {
+        String basePath = sanitizeBasePath(resolvedStorybookConfig.getBasePath());
+        String cssPath = basePath + "/css/**";
+        String jsPath = basePath + "/js/**";
+        String imagePath = basePath + "/images/**";
         return new WebMvcConfigurer() {
             @Override
             public void addResourceHandlers(ResourceHandlerRegistry registry) {
                 // 静的リソース専用パスを限定（コントローラーマッピングと競合を避ける）
-                registry.addResourceHandler("/thymeleaflet/css/**")
+                registry.addResourceHandler(cssPath)
                         .addResourceLocations("classpath:/META-INF/resources/static/css/");
-                registry.addResourceHandler("/thymeleaflet/js/**")
+                registry.addResourceHandler(jsPath)
                         .addResourceLocations("classpath:/META-INF/resources/static/js/");
-                registry.addResourceHandler("/thymeleaflet/images/**")
+                registry.addResourceHandler(imagePath)
                         .addResourceLocations("classpath:/META-INF/resources/static/images/");
                         
                 // CSS専用ハンドラー（fallback）（キャッシュなし）
@@ -191,5 +195,19 @@ public class StorybookAutoConfiguration {
         messageSource.setFallbackToSystemLocale(false);
         messageSource.setDefaultEncoding("UTF-8");
         return messageSource;
+    }
+
+    private static String sanitizeBasePath(String basePath) {
+        String trimmed = basePath.trim();
+        if (trimmed.isEmpty() || "/".equals(trimmed)) {
+            return "";
+        }
+        if (!trimmed.startsWith("/")) {
+            trimmed = "/" + trimmed;
+        }
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/FragmentListController.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/FragmentListController.java
@@ -1,6 +1,7 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.controller;
 
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery.FragmentDiscoveryService;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.FragmentMainContentService;
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.ThymeleafletVersionResolver;
 import org.slf4j.Logger;
@@ -32,6 +33,9 @@ public class FragmentListController {
 
     @Autowired
     private ThymeleafletVersionResolver thymeleafletVersionResolver;
+
+    @Autowired
+    private ResolvedStorybookConfig resolvedStorybookConfig;
     
     /**
      * Storybookメインエントリーポイント - フラグメント一覧ページ (プレースホルダ最適化版)
@@ -44,6 +48,7 @@ public class FragmentListController {
         long startTime = System.currentTimeMillis();
         logger.info("=== Fragment List (Placeholder Optimized) START ===");
         model.addAttribute("thymeleafletVersion", thymeleafletVersionResolver.resolve());
+        model.addAttribute("basePath", resolvedStorybookConfig.getBasePath());
         
         // 初期レンダリング時は重い処理をスキップ - フラグメント発見のみ実行
         List<FragmentDiscoveryService.FragmentInfo> fragments = fragmentDiscoveryService.discoverFragments();

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -6,7 +6,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathV
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
@@ -35,13 +34,19 @@ public class FragmentDependencyService implements FragmentDependencyPort {
         "th:(?:replace|include|insert)\\s*=\\s*"
     );
 
-    @Autowired
-    private ResolvedStorybookConfig storybookConfig;
+    private final ResolvedStorybookConfig storybookConfig;
 
-    @Autowired
-    private ResourcePathValidator resourcePathValidator;
+    private final ResourcePathValidator resourcePathValidator;
 
     private final Map<String, List<DependencyComponent>> dependencyCache = new ConcurrentHashMap<>();
+
+    public FragmentDependencyService(
+        ResolvedStorybookConfig storybookConfig,
+        ResourcePathValidator resourcePathValidator
+    ) {
+        this.storybookConfig = storybookConfig;
+        this.resourcePathValidator = resourcePathValidator;
+    }
 
     public List<DependencyComponent> findDependencies(String templatePath, String fragmentName) {
         if (storybookConfig.getCache().isEnabled()) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentJsonService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentJsonService.java
@@ -10,7 +10,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSumm
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -32,17 +31,25 @@ public class FragmentJsonService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentJsonService.class);
     
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
     
-    @Autowired
-    private FragmentPreviewUseCase fragmentPreviewUseCase;
+    private final FragmentPreviewUseCase fragmentPreviewUseCase;
     
-    @Autowired
-    private FragmentSummaryMapper fragmentSummaryMapper;
+    private final FragmentSummaryMapper fragmentSummaryMapper;
 
-    @Autowired
-    private StoryParameterUseCase storyParameterUseCase;
+    private final StoryParameterUseCase storyParameterUseCase;
+
+    public FragmentJsonService(
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        FragmentPreviewUseCase fragmentPreviewUseCase,
+        FragmentSummaryMapper fragmentSummaryMapper,
+        StoryParameterUseCase storyParameterUseCase
+    ) {
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.fragmentPreviewUseCase = fragmentPreviewUseCase;
+        this.fragmentSummaryMapper = fragmentSummaryMapper;
+        this.storyParameterUseCase = storyParameterUseCase;
+    }
 
     /**
      * フラグメントリストを拡張JSON形式に変換してModel属性に設定

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentMainContentService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentMainContentService.java
@@ -9,7 +9,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSumm
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -30,26 +29,37 @@ public class FragmentMainContentService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentMainContentService.class);
     
-    @Autowired
-    private FragmentDiscoveryService fragmentDiscoveryService;
+    private final FragmentDiscoveryService fragmentDiscoveryService;
     
-    @Autowired
-    private FragmentStatisticsUseCase fragmentStatisticsUseCase;
+    private final FragmentStatisticsUseCase fragmentStatisticsUseCase;
     
-    @Autowired
-    private FragmentHierarchyUseCase fragmentHierarchyUseCase;
+    private final FragmentHierarchyUseCase fragmentHierarchyUseCase;
     
-    @Autowired
-    private FragmentJsonService fragmentJsonService;
+    private final FragmentJsonService fragmentJsonService;
     
-    @Autowired
-    private FragmentSummaryMapper fragmentSummaryMapper;
+    private final FragmentSummaryMapper fragmentSummaryMapper;
 
-    @Autowired
-    private ResolvedStorybookConfig storybookConfig;
+    private final ResolvedStorybookConfig storybookConfig;
 
-    @Autowired
-    private PreviewConfigService previewConfigService;
+    private final PreviewConfigService previewConfigService;
+
+    public FragmentMainContentService(
+        FragmentDiscoveryService fragmentDiscoveryService,
+        FragmentStatisticsUseCase fragmentStatisticsUseCase,
+        FragmentHierarchyUseCase fragmentHierarchyUseCase,
+        FragmentJsonService fragmentJsonService,
+        FragmentSummaryMapper fragmentSummaryMapper,
+        ResolvedStorybookConfig storybookConfig,
+        PreviewConfigService previewConfigService
+    ) {
+        this.fragmentDiscoveryService = fragmentDiscoveryService;
+        this.fragmentStatisticsUseCase = fragmentStatisticsUseCase;
+        this.fragmentHierarchyUseCase = fragmentHierarchyUseCase;
+        this.fragmentJsonService = fragmentJsonService;
+        this.fragmentSummaryMapper = fragmentSummaryMapper;
+        this.storybookConfig = storybookConfig;
+        this.previewConfigService = previewConfigService;
+    }
     
     /**
      * メインコンテンツ遅延読み込み処理

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
@@ -10,7 +10,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.web.service.SecurePathConve
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -30,20 +29,29 @@ public class FragmentRenderingService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentRenderingService.class);
     
-    @Autowired
-    private ValidationUseCase validationUseCase;
+    private final ValidationUseCase validationUseCase;
     
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
     
-    @Autowired
-    private StoryParameterUseCase storyParameterUseCase;
+    private final StoryParameterUseCase storyParameterUseCase;
     
-    @Autowired
-    private SecurePathConversionService securePathConversionService;
+    private final SecurePathConversionService securePathConversionService;
 
-    @Autowired
-    private ThymeleafFragmentRenderer thymeleafFragmentRenderer;
+    private final ThymeleafFragmentRenderer thymeleafFragmentRenderer;
+
+    public FragmentRenderingService(
+        ValidationUseCase validationUseCase,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        StoryParameterUseCase storyParameterUseCase,
+        SecurePathConversionService securePathConversionService,
+        ThymeleafFragmentRenderer thymeleafFragmentRenderer
+    ) {
+        this.validationUseCase = validationUseCase;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.storyParameterUseCase = storyParameterUseCase;
+        this.securePathConversionService = securePathConversionService;
+        this.thymeleafFragmentRenderer = thymeleafFragmentRenderer;
+    }
     
     /**
      * ストーリー動的レンダリング処理

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/PreviewConfigService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/PreviewConfigService.java
@@ -1,7 +1,6 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
@@ -17,11 +16,14 @@ import java.util.Locale;
 @Component
 public class PreviewConfigService {
 
-    @Autowired
-    private ResolvedStorybookConfig storybookConfig;
+    private final ResolvedStorybookConfig storybookConfig;
 
-    @Autowired
-    private MessageSource messageSource;
+    private final MessageSource messageSource;
+
+    public PreviewConfigService(ResolvedStorybookConfig storybookConfig, MessageSource messageSource) {
+        this.storybookConfig = storybookConfig;
+        this.messageSource = messageSource;
+    }
 
     public void applyPreviewConfig(Model model) {
         ResolvedStorybookConfig.PreviewConfig preview = storybookConfig.getPreview();

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryCommonDataService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryCommonDataService.java
@@ -7,7 +7,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStory
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.ThymeleafFragmentRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -32,26 +31,37 @@ public class StoryCommonDataService {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryCommonDataService.class);
     
-    @Autowired
-    private StoryParameterUseCase storyParameterUseCase;
+    private final StoryParameterUseCase storyParameterUseCase;
     
-    @Autowired
-    private ThymeleafFragmentRenderer thymeleafFragmentRenderer;
+    private final ThymeleafFragmentRenderer thymeleafFragmentRenderer;
     
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
     
-    @Autowired
-    private JavaDocLookupService javaDocLookupService;
+    private final JavaDocLookupService javaDocLookupService;
 
-    @Autowired
-    private FragmentDependencyService fragmentDependencyService;
+    private final FragmentDependencyService fragmentDependencyService;
 
-    @Autowired
-    private ResolvedStorybookConfig storybookConfig;
+    private final ResolvedStorybookConfig storybookConfig;
 
-    @Autowired
-    private PreviewConfigService previewConfigService;
+    private final PreviewConfigService previewConfigService;
+
+    public StoryCommonDataService(
+        StoryParameterUseCase storyParameterUseCase,
+        ThymeleafFragmentRenderer thymeleafFragmentRenderer,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        JavaDocLookupService javaDocLookupService,
+        FragmentDependencyService fragmentDependencyService,
+        ResolvedStorybookConfig storybookConfig,
+        PreviewConfigService previewConfigService
+    ) {
+        this.storyParameterUseCase = storyParameterUseCase;
+        this.thymeleafFragmentRenderer = thymeleafFragmentRenderer;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.javaDocLookupService = javaDocLookupService;
+        this.fragmentDependencyService = fragmentDependencyService;
+        this.storybookConfig = storybookConfig;
+        this.previewConfigService = previewConfigService;
+    }
     
     /**
      * フラグメント・ストーリー共通データセットアップ

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryContentService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryContentService.java
@@ -5,7 +5,6 @@ import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSummaryMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -22,17 +21,25 @@ public class StoryContentService {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryContentService.class);
     
-    @Autowired
-    private StoryContentCoordinationUseCase storyContentCoordinationUseCase;
+    private final StoryContentCoordinationUseCase storyContentCoordinationUseCase;
     
-    @Autowired
-    private StoryCommonDataService storyCommonDataService;
+    private final StoryCommonDataService storyCommonDataService;
     
-    @Autowired
-    private SecurePathConversionService securePathConversionService;
+    private final SecurePathConversionService securePathConversionService;
 
-    @Autowired
-    private FragmentSummaryMapper fragmentSummaryMapper;
+    private final FragmentSummaryMapper fragmentSummaryMapper;
+
+    public StoryContentService(
+        StoryContentCoordinationUseCase storyContentCoordinationUseCase,
+        StoryCommonDataService storyCommonDataService,
+        SecurePathConversionService securePathConversionService,
+        FragmentSummaryMapper fragmentSummaryMapper
+    ) {
+        this.storyContentCoordinationUseCase = storyContentCoordinationUseCase;
+        this.storyCommonDataService = storyCommonDataService;
+        this.securePathConversionService = securePathConversionService;
+        this.fragmentSummaryMapper = fragmentSummaryMapper;
+    }
     
     /**
      * ストーリーコンテンツHTMX処理

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryPreviewService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryPreviewService.java
@@ -5,7 +5,6 @@ import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryRetrie
 import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 
@@ -25,22 +24,26 @@ public class StoryPreviewService {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryPreviewService.class);
     
-    @Autowired
-    private StoryPageCoordinationUseCase storyPageCoordinationUseCase;
-    
-    
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
-    
-    @Autowired
-    private FragmentJsonService fragmentJsonService;
-    
-    @Autowired
-    private StoryCommonDataService storyCommonDataService;
-    
-    @Autowired
-    private SecurePathConversionService securePathConversionService;
-    
+    private final StoryPageCoordinationUseCase storyPageCoordinationUseCase;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
+    private final FragmentJsonService fragmentJsonService;
+    private final StoryCommonDataService storyCommonDataService;
+    private final SecurePathConversionService securePathConversionService;
+
+    public StoryPreviewService(
+        StoryPageCoordinationUseCase storyPageCoordinationUseCase,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        FragmentJsonService fragmentJsonService,
+        StoryCommonDataService storyCommonDataService,
+        SecurePathConversionService securePathConversionService
+    ) {
+        this.storyPageCoordinationUseCase = storyPageCoordinationUseCase;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.fragmentJsonService = fragmentJsonService;
+        this.storyCommonDataService = storyCommonDataService;
+        this.securePathConversionService = securePathConversionService;
+    }
+
     
     /**
      * ストーリープレビューページ処理

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UsageExampleService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UsageExampleService.java
@@ -9,7 +9,6 @@ import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -28,17 +27,25 @@ public class UsageExampleService {
     
     private static final Logger logger = LoggerFactory.getLogger(UsageExampleService.class);
     
-    @Autowired
-    private ValidationUseCase validationUseCase;
+    private final ValidationUseCase validationUseCase;
     
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
     
-    @Autowired
-    private StoryParameterUseCase storyParameterUseCase;
+    private final StoryParameterUseCase storyParameterUseCase;
     
-    @Autowired
-    private UsageExampleUseCase usageExampleUseCase;
+    private final UsageExampleUseCase usageExampleUseCase;
+
+    public UsageExampleService(
+        ValidationUseCase validationUseCase,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        StoryParameterUseCase storyParameterUseCase,
+        UsageExampleUseCase usageExampleUseCase
+    ) {
+        this.validationUseCase = validationUseCase;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.storyParameterUseCase = storyParameterUseCase;
+        this.usageExampleUseCase = usageExampleUseCase;
+    }
     
     /**
      * 使用例生成処理

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentMainContentServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentMainContentServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.StaticMessageSource;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 
@@ -43,22 +42,21 @@ class FragmentMainContentServiceTest {
 
     @Test
     void setupMainContent_setsPreviewResourcesFromProperties() {
-        FragmentMainContentService service = new FragmentMainContentService();
-
         StorybookProperties properties = new StorybookProperties();
         StorybookProperties.ResourceConfig resources = new StorybookProperties.ResourceConfig();
         resources.setStylesheets(List.of("/css/app.css"));
         resources.setScripts(List.of("/js/app.js"));
         properties.setResources(resources);
         PreviewConfigService previewConfigService = buildPreviewConfigService(properties);
-
-        ReflectionTestUtils.setField(service, "storybookConfig", ResolvedStorybookConfig.from(properties));
-        ReflectionTestUtils.setField(service, "fragmentDiscoveryService", fragmentDiscoveryService);
-        ReflectionTestUtils.setField(service, "fragmentStatisticsUseCase", fragmentStatisticsUseCase);
-        ReflectionTestUtils.setField(service, "fragmentHierarchyUseCase", fragmentHierarchyUseCase);
-        ReflectionTestUtils.setField(service, "fragmentJsonService", fragmentJsonService);
-        ReflectionTestUtils.setField(service, "fragmentSummaryMapper", fragmentSummaryMapper);
-        ReflectionTestUtils.setField(service, "previewConfigService", previewConfigService);
+        FragmentMainContentService service = new FragmentMainContentService(
+            fragmentDiscoveryService,
+            fragmentStatisticsUseCase,
+            fragmentHierarchyUseCase,
+            fragmentJsonService,
+            fragmentSummaryMapper,
+            ResolvedStorybookConfig.from(properties),
+            previewConfigService
+        );
 
         FragmentDiscoveryService.FragmentInfo infraFragment = new FragmentDiscoveryService.FragmentInfo(
             "components/button",
@@ -96,10 +94,7 @@ class FragmentMainContentServiceTest {
     }
 
     private PreviewConfigService buildPreviewConfigService(StorybookProperties properties) {
-        PreviewConfigService previewConfigService = new PreviewConfigService();
         StaticMessageSource messageSource = new StaticMessageSource();
-        ReflectionTestUtils.setField(previewConfigService, "storybookConfig", ResolvedStorybookConfig.from(properties));
-        ReflectionTestUtils.setField(previewConfigService, "messageSource", messageSource);
-        return previewConfigService;
+        return new PreviewConfigService(ResolvedStorybookConfig.from(properties), messageSource);
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryCommonDataServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryCommonDataServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.StaticMessageSource;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 
@@ -49,22 +48,13 @@ class StoryCommonDataServiceTest {
 
     @Test
     void setupCommonStoryData_setsPreviewResourcesFromProperties() {
-        StoryCommonDataService service = new StoryCommonDataService();
-
         StorybookProperties properties = new StorybookProperties();
         StorybookProperties.ResourceConfig resources = new StorybookProperties.ResourceConfig();
         resources.setStylesheets(List.of(" /css/app.css ", "/css/theme.css"));
         resources.setScripts(List.of("/js/app.js", " /js/vendor.js "));
         properties.setResources(resources);
         PreviewConfigService previewConfigService = buildPreviewConfigService(properties);
-
-        ReflectionTestUtils.setField(service, "storybookConfig", ResolvedStorybookConfig.from(properties));
-        ReflectionTestUtils.setField(service, "storyParameterUseCase", storyParameterUseCase);
-        ReflectionTestUtils.setField(service, "thymeleafFragmentRenderer", thymeleafFragmentRenderer);
-        ReflectionTestUtils.setField(service, "storyRetrievalUseCase", storyRetrievalUseCase);
-        ReflectionTestUtils.setField(service, "javaDocLookupService", javaDocLookupService);
-        ReflectionTestUtils.setField(service, "fragmentDependencyService", fragmentDependencyService);
-        ReflectionTestUtils.setField(service, "previewConfigService", previewConfigService);
+        StoryCommonDataService service = buildStoryCommonDataService(properties, previewConfigService);
 
         FragmentSummary summary = FragmentSummary.of(
             "components/button",
@@ -97,18 +87,9 @@ class StoryCommonDataServiceTest {
 
     @Test
     void setupCommonStoryData_ordersParametersByJavaDocThenSignatureThenStoryExtras() {
-        StoryCommonDataService service = new StoryCommonDataService();
-
         StorybookProperties properties = new StorybookProperties();
         PreviewConfigService previewConfigService = buildPreviewConfigService(properties);
-
-        ReflectionTestUtils.setField(service, "storybookConfig", ResolvedStorybookConfig.from(properties));
-        ReflectionTestUtils.setField(service, "storyParameterUseCase", storyParameterUseCase);
-        ReflectionTestUtils.setField(service, "thymeleafFragmentRenderer", thymeleafFragmentRenderer);
-        ReflectionTestUtils.setField(service, "storyRetrievalUseCase", storyRetrievalUseCase);
-        ReflectionTestUtils.setField(service, "javaDocLookupService", javaDocLookupService);
-        ReflectionTestUtils.setField(service, "fragmentDependencyService", fragmentDependencyService);
-        ReflectionTestUtils.setField(service, "previewConfigService", previewConfigService);
+        StoryCommonDataService service = buildStoryCommonDataService(properties, previewConfigService);
 
         FragmentSummary summary = FragmentSummary.of(
             "components/button",
@@ -160,11 +141,23 @@ class StoryCommonDataServiceTest {
         );
     }
 
+    private StoryCommonDataService buildStoryCommonDataService(
+        StorybookProperties properties,
+        PreviewConfigService previewConfigService
+    ) {
+        return new StoryCommonDataService(
+            storyParameterUseCase,
+            thymeleafFragmentRenderer,
+            storyRetrievalUseCase,
+            javaDocLookupService,
+            fragmentDependencyService,
+            ResolvedStorybookConfig.from(properties),
+            previewConfigService
+        );
+    }
+
     private PreviewConfigService buildPreviewConfigService(StorybookProperties properties) {
-        PreviewConfigService previewConfigService = new PreviewConfigService();
         StaticMessageSource messageSource = new StaticMessageSource();
-        ReflectionTestUtils.setField(previewConfigService, "storybookConfig", ResolvedStorybookConfig.from(properties));
-        ReflectionTestUtils.setField(previewConfigService, "messageSource", messageSource);
-        return previewConfigService;
+        return new PreviewConfigService(ResolvedStorybookConfig.from(properties), messageSource);
     }
 }


### PR DESCRIPTION
## Summary
- Split work into 2 commits on a single branch as requested for `cmd_20260209_013`.
- Commit 1: unify base-path usage to follow `thymeleaflet.base-path` in key configuration/controllers.
- Commit 2: convert key web/service classes from field injection to constructor injection.

## Commits (latest 2)
- `688e753` refactor: switch core web services to constructor injection
- `a9c8979` refactor: unify base path usage across config and security

## Scope highlights
- Base-path unification includes:
  - `StorybookAutoConfiguration.java`
  - `ThymeleafletSecurityConfig.java`
  - `FragmentListController.java`
- Constructor injection refactor applied to major service/controller paths in this branch.

## Static verification (`rg`)
- `rg '/thymeleaflet'` still returns multiple matches across templates/resources/annotations/default values.
- `rg '@Autowired'` still returns matches in other classes/tests outside this incremental scope.
- This PR covers the requested split and focused files; remaining occurrences are documented for follow-up scope.

## Test preflight / execution feasibility
- `java -version` => command not found
- `./mvnw -v` => `JAVA_HOME` not defined correctly
- Due to missing Java runtime/configuration, tests were not executable in this environment.
