### PR TITLE
fix: fail fast when thymeleaflet.base-path is not supported

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -11,6 +11,9 @@
 | `thymeleaflet.base-path` | String | `/thymeleaflet` | UI のベースパス |
 | `thymeleaflet.debug` | boolean | `false` | フラグメント探索のデバッグログ |
 
+`thymeleaflet.base-path` は現在 `/thymeleaflet` のみサポートしています。
+別のパスを設定すると起動時にエラーになります。
+
 ## リソース設定
 
 | プロパティ | 型 | デフォルト | 説明 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,9 @@ This page covers *only* configuration. Usage details are in
 | `thymeleaflet.base-path` | String | `/thymeleaflet` | Base URL for the UI |
 | `thymeleaflet.debug` | boolean | `false` | Enables debug logging for fragment discovery |
 
+`thymeleaflet.base-path` currently supports only `/thymeleaflet`.
+Using another path fails fast at startup.
+
 ## Resource Configuration
 
 | Property | Type | Default | Description |

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -100,6 +100,9 @@ spring:
 
 本番ビルドから依存関係を外す運用でも問題ありません。
 
+`thymeleaflet.base-path` は現在 `/thymeleaflet` のみサポートしています。
+別のパスを設定すると起動時にエラーになります。
+
 ## 代表的な配置場所
 
 - テンプレート: `src/main/resources/templates/**`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,6 +100,9 @@ spring:
 
 Alternatively, remove the dependency from production builds.
 
+`thymeleaflet.base-path` currently supports only `/thymeleaflet`.
+Using another path fails fast at startup.
+
 ## Project Layout
 
 - Templates: `src/main/resources/templates/**`

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfig.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfig.java
@@ -39,7 +39,12 @@ public final class ResolvedStorybookConfig {
 
     public static ResolvedStorybookConfig from(StorybookProperties raw) {
         Objects.requireNonNull(raw, "raw cannot be null");
-        String basePath = normalizeOrDefault(raw.getBasePath(), DEFAULT_BASE_PATH);
+        String basePath = normalizeBasePath(raw.getBasePath());
+        if (!DEFAULT_BASE_PATH.equals(basePath)) {
+            throw new IllegalArgumentException(
+                "Only '/thymeleaflet' is currently supported for thymeleaflet.base-path. Configured value: " + basePath
+            );
+        }
         StorybookProperties.ResourceConfig rawResources = raw.getResources();
         StorybookProperties.CacheConfig rawCache = raw.getCache();
         StorybookProperties.PreviewConfig rawPreview = raw.getPreview();
@@ -270,6 +275,17 @@ public final class ResolvedStorybookConfig {
         }
         String normalized = value.trim();
         return normalized.isEmpty() ? defaultValue : normalized;
+    }
+
+    private static String normalizeBasePath(@Nullable String value) {
+        String normalized = normalizeOrDefault(value, DEFAULT_BASE_PATH);
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        if (normalized.endsWith("/") && normalized.length() > 1) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
     }
 
     private static List<String> sanitizeNonBlankList(@Nullable List<String> values, String fieldName) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfigTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfigTest.java
@@ -68,4 +68,24 @@ class ResolvedStorybookConfigTest {
         assertThat(resolved.getResources().getStylesheets()).containsExactly("/css/a.css");
         assertThat(resolved.getResources().getScripts()).containsExactly("/js/a.js");
     }
+
+    @Test
+    void from_rejectsNonDefaultBasePath() {
+        StorybookProperties raw = new StorybookProperties();
+        raw.setBasePath("/thymeleaflet2");
+
+        assertThatThrownBy(() -> ResolvedStorybookConfig.from(raw))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Only '/thymeleaflet' is currently supported for thymeleaflet.base-path. Configured value: /thymeleaflet2");
+    }
+
+    @Test
+    void from_normalizesEquivalentBasePathToDefault() {
+        StorybookProperties raw = new StorybookProperties();
+        raw.setBasePath(" thymeleaflet/ ");
+
+        ResolvedStorybookConfig resolved = ResolvedStorybookConfig.from(raw);
+
+        assertThat(resolved.getBasePath()).isEqualTo("/thymeleaflet");
+    }
 }


### PR DESCRIPTION
## Summary
- validate `thymeleaflet.base-path` at config resolution and allow only `/thymeleaflet`
- normalize equivalent inputs (e.g. `thymeleaflet/`) to `/thymeleaflet`
- fail fast at startup with clear error for unsupported values
- document the current fixed base-path limitation in getting-started/configuration (EN/JA)
- add tests for reject + normalization behavior

## Why
Changing base-path to values like `/thymeleaflet2` currently breaks UI/static resource assumptions. This change makes the limitation explicit and prevents silent broken rendering.

## Verification
- `mvn -DskipTests install`
- `mvn test -Dtest=ResolvedStorybookConfigTest`
- `npm run test:e2e` (8 passed)

Closes #80
