### PR TITLE
chore: prepare release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.6] - 2026-02-09
+
+- Changed
+  - Unified base-path handling across configuration and security integration paths.
+  - Switched core web service wiring to constructor injection for clearer dependency boundaries.
+- Fixed
+  - Added fail-fast validation for `thymeleaflet.base-path`; only `/thymeleaflet` is supported and unsupported values now fail at startup with a clear message.
+- Test
+  - Adapted service tests to constructor injection and added coverage for base-path normalization/rejection behavior.
+- Docs
+  - Aligned story path / naming guidance and Java build requirement notes in README docs.
+  - Clarified fixed base-path limitation (`/thymeleaflet`) in configuration/getting-started docs.
+  - Updated installation version examples in `README.md` / `README.ja.md` to `0.2.6`.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.6`.
+
+### Issues
+
+- #79 Review fixes for base-path and DI updates
+- #80 Fail fast when thymeleaflet.base-path is not /thymeleaflet
+
 ## [0.2.5] - 2026-02-08
 
 - Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.6</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.1.0")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.6")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.6</version>
 </dependency>
 ```
 
@@ -62,7 +62,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.1.0")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.6")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.5</version>
+            <version>0.2.6</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump library and sample versions to `0.2.6`
- add `0.2.6` release notes to `CHANGELOG.md`
- update installation version examples in `README.md` and `README.ja.md`

## Verification
- `mvn -DskipTests install`
- `npm run test:e2e` (8 passed)

Closes #82
