### PR TITLE
Prepare v0.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.8] - 2026-02-11
+
+- Added
+  - Added explicit custom-parameter type switching (`string` / `number` / `boolean` / `object` / `array`) in Custom story editing.
+  - Added NULL toggle support for custom parameters with value restoration behavior when toggling back off.
+  - Added custom-parameter reset action to clear session-saved custom values and restore defaults from the first/default story.
+- Changed
+  - Improved fallback inference for collection/map-like parameters in `StoryParameterDomainService` with parameter-name-aware defaults.
+  - Aligned Custom parameter controls and reset icon placement to improve editing flow in the parameter panel.
+  - Updated mobile navigation UX so the sidebar open button is available beside the fragment title without reserving extra header space.
+  - Made mobile sidebar button placement consistent between initial page render and HTMX-swapped main content.
+- Fixed
+  - Isolated Thymeleaflet message bundles from host application `messages*.properties` to prevent i18n key collisions.
+  - Guarded unsafe fragment insertion parameter patterns (`th:replace` / `th:insert` with plain strings) to avoid preview-time template resolution failures.
+  - Restored mobile fragment-list accessibility so users can reliably reopen the sidebar after closing it.
+  - Fixed fallback-story badge handling and source-panel rendering issues (including signature/implementation display refinements).
+- Docs
+  - Expanded EN/JA documentation for safe fragment insertion patterns and story parameter design guidance.
+  - Updated EN/JA stories docs to explain type inference/fallback behavior and boundaries.
+- Test
+  - Added regression tests for fallback inference behavior (`options`/list/map paths).
+  - Added/updated integration coverage for i18n isolation and rendering-exception guard behavior.
+  - Added mobile sidebar open/close E2E regression coverage and re-ran full E2E suite.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.8`.
+
+### Issues
+
+- #88 Fix message bundle basename collision with consumer apps
+- #90 Guard unsafe fragment insertion parameters and improve guidance
+- #92 Fix collection-like fallback inference for custom story params
+- #95 Bug: mobile view cannot reopen fragment list sidebar
+
 ## [0.2.7] - 2026-02-11
 
 - Changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,38 @@ git tag vX.Y.Z
 5) Verify that the staging repository is closed and released in Sonatype (auto-release enabled).
 6) Check Maven Central for the published artifacts.
 
+## How To Collect Release Changes (Checklist)
+
+Before editing `CHANGELOG.md`, always collect all merged changes since the last tag.
+
+1) Identify the previous release tag:
+
+```bash
+git tag --sort=version:refname | tail -n 1
+```
+
+2) List commits since the previous tag:
+
+```bash
+git log --oneline <PREVIOUS_TAG>..main
+```
+
+3) List merged PRs since the previous tag date:
+
+```bash
+gh pr list --state merged --base main --search "merged:>=YYYY-MM-DD" --json number,title,mergedAt,headRefName
+```
+
+4) For each candidate PR, open summary/details and map to changelog categories:
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,body,url,mergedAt
+```
+
+5) Update `CHANGELOG.md` categories (`Added` / `Changed` / `Fixed` / `Removed` / `Refactored` / `Docs` / `Build` / `Test`) and include related issue numbers.
+
+This prevents missing important fixes/features in release notes.
+
 ## Snapshot Deploy
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.7</version>
+            <version>0.2.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- prepare `v0.2.8` release branch updates
- bump project versions to `0.2.8` in:
  - `pom.xml`
  - `sample/pom.xml`
- update `CHANGELOG.md` with complete release notes since `v0.2.7` (including #89, #91, #93, #94)
- add a persistent release-note collection checklist to `RELEASE.md` to avoid missing merged changes in future releases

## Verification
- `mvn -DskipTests install`
- start sample app: `cd sample && mvn spring-boot:run -DskipTests`
- `npm run test:e2e`
  - result: 9 passed, 0 failed

## Notes
- Release notes for `0.2.8` now include i18n collision fix, unsafe fragment insertion guard, fallback inference/custom editor enhancements, and mobile sidebar accessibility recovery.

Closes #95
