### PR TITLE
fix: show mobile hamburger menu on initial top placeholder

### DIFF
--- a/src/main/resources/templates/thymeleaflet/fragment-list.html
+++ b/src/main/resources/templates/thymeleaflet/fragment-list.html
@@ -50,6 +50,16 @@
                 <div th:unless="${selectedFragment != null and selectedStory != null}" id="main-content-placeholder" class="animate-pulse">
                     <!-- ウェルカムメッセージプレースホルダ -->
                     <div class="text-center py-16">
+                        <div class="lg:hidden flex justify-start mb-6">
+                            <button id="sidebar-open-button-placeholder"
+                                    aria-label="Open sidebar"
+                                    class="p-2 rounded-md text-gray-400 hover:text-gray-600"
+                                    @click="sidebarOpen = true">
+                                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                                </svg>
+                            </button>
+                        </div>
                         <div class="mx-auto w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center mb-4">
                             <div class="w-8 h-8 bg-gray-300 rounded"></div>
                         </div>

--- a/tests/e2e/preview.spec.js
+++ b/tests/e2e/preview.spec.js
@@ -22,13 +22,16 @@ test('simpleCard preview matches snapshot', async ({ page }) => {
 });
 
 test('mobile menu button opens fragment sidebar', async ({ page }) => {
-  await openFragment(page, 'simpleCard');
   await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/thymeleaflet/');
   const sidebar = page.locator('.nav-sidebar');
-  await expect(page.locator('#sidebar-open-button')).toBeVisible();
+  const openButton = page.locator(
+    '#sidebar-open-button-placeholder, #sidebar-open-button-welcome, #sidebar-open-button'
+  ).first();
+  await expect(openButton).toBeVisible();
   await expect(sidebar).not.toHaveClass(/mobile-open/);
 
-  await page.locator('#sidebar-open-button').click();
+  await openButton.click();
   await expect(sidebar).toHaveClass(/mobile-open/);
   await expect(page.locator('#sidebar-close-button')).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Fix mobile top page behavior where the hamburger menu was still missing during the initial placeholder render.
- Ensure users can open the sidebar immediately on `/thymeleaflet` in mobile view.

## Changes
- Updated `src/main/resources/templates/thymeleaflet/fragment-list.html`
  - Added mobile-only sidebar open button to the initial placeholder state.
- Updated `tests/e2e/preview.spec.js`
  - Changed mobile menu test to validate initial top-page state (`/thymeleaflet/`) and accept placeholder/welcome/main button IDs.

## Verification
- `mvn -DskipTests install`
- `npm run test:e2e`
  - Result: 9 passed

## Issue
- No linked issue (direct fix request).
