### PR TITLE
fix: satisfy architecture rule for domain analyzer

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -2,7 +2,6 @@ package io.github.wamukat.thymeleaflet.domain.service;
 
 import io.github.wamukat.thymeleaflet.domain.model.ModelPath;
 import io.github.wamukat.thymeleaflet.domain.model.TemplateInference;
-import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -18,7 +17,6 @@ import java.util.regex.Pattern;
 /**
  * テンプレート式を解析し、モデル推論に必要な情報を抽出する。
  */
-@Component
 public class TemplateModelExpressionAnalyzer {
 
     private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{([^}]*)}");

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -6,6 +6,7 @@ import io.github.wamukat.thymeleaflet.domain.service.DocumentationAnalysisServic
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.domain.service.StoryDataRepository;
 import io.github.wamukat.thymeleaflet.domain.service.StoryParameterDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.TemplateModelExpressionAnalyzer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -68,6 +69,12 @@ public class StorybookAutoConfiguration {
         DocumentationAnalysisService documentationAnalysisService
     ) {
         return new StoryParameterDomainService(storyDataRepository, documentationAnalysisService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TemplateModelExpressionAnalyzer templateModelExpressionAnalyzer() {
+        return new TemplateModelExpressionAnalyzer();
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove `@Component` from `TemplateModelExpressionAnalyzer` in `domain` package
- register `TemplateModelExpressionAnalyzer` as a bean in `StorybookAutoConfiguration`
- keep existing DI for `FragmentModelInferenceService` without violating architecture rules

## Why
`ArchitectureConstraintArchTest` rejects Spring stereotypes in `..domain..`.
This change keeps the class as a domain object while wiring happens in infrastructure configuration.

## Validation
- `mvn -Dtest=ArchitectureConstraintArchTest test -q`
- `mvn -Dtest=FragmentModelInferenceServiceTest test -q`
- `./mvnw -Prelease clean deploy` (BUILD SUCCESS)
- `npm run test:e2e` (9 passed; sample app started on `6006` for this test run)

Closes #103
