### PR TITLE
fix: show hamburger button in welcome main-content

### DIFF
--- a/src/main/resources/templates/thymeleaflet/fragments/main-content.html
+++ b/src/main/resources/templates/thymeleaflet/fragments/main-content.html
@@ -548,6 +548,16 @@
     
     <!-- フラグメント未選択時の表示 -->
     <div class="text-center py-16">
+        <div class="lg:hidden flex justify-start mb-6">
+            <button id="sidebar-open-button-welcome"
+                    aria-label="Open sidebar"
+                    class="p-2 rounded-md text-gray-400 hover:text-gray-600"
+                    @click="sidebarOpen = true">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                </svg>
+            </button>
+        </div>
         <div class="mx-auto w-40 h-40 flex items-center justify-center mb-4">
             <img th:src="@{/thymeleaflet/images/thymeleaflet-logo.png}"
                  alt="Thymeleaflet"


### PR DESCRIPTION
## Summary
- add mobile hamburger button to the "no fragment selected" welcome section in `fragments/main-content.html`
- ensure sidebar can be reopened on top page after `#main-content-area` replacement

## Root cause
The initial page had hamburger buttons, but after HTMX/fragment replacement to `main-content.html`, the welcome block rendered without any mobile open button.

## Validation
- Playwright mobile check (`390x844`): `#sidebar-open-button-welcome` is visible
- `npm run test:e2e -- --grep "mobile menu button opens fragment sidebar"`

Closes #105
