### PR TITLE
chore(release): prepare 0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.10] - 2026-02-12
+
+- Fixed
+  - Fixed architecture rule violation by removing Spring stereotype annotation from `TemplateModelExpressionAnalyzer` in the `domain` package and wiring it from auto-configuration.
+  - Fixed mobile top-page welcome view after HTMX/main-content replacement by restoring the sidebar open (hamburger) button in the welcome block.
+- Test
+  - Re-ran targeted mobile sidebar E2E regression to confirm open-button visibility and sidebar reopening behavior.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.10`.
+
+### Issues
+
+- #103 Fix architecture test failure for domain analyzer bean
+- #105 Fix missing mobile hamburger button in welcome main-content
+
 ## [0.2.9] - 2026-02-12
 
 - Added

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.9</version>
+    <version>0.2.10</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.9</version>
+    <version>0.2.10</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump starter version from `0.2.9` to `0.2.10`
- bump sample app version/dependency to `0.2.10`
- add `0.2.10` changelog entry

## Validation
- `mvn -DskipTests install`
- `npm run test:e2e` (9 passed)

Closes #107
