### PR TITLE
fix: avoid child model leakage for literal-only fragment args

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
@@ -12,16 +12,16 @@ public final class TemplateInference {
 
     private final List<ModelPath> modelPaths;
     private final Map<String, ModelPath> loopVariablePaths;
-    private final Set<String> referencedTemplatePaths;
+    private final Map<String, Boolean> referencedTemplatePaths;
 
     public TemplateInference(
         List<ModelPath> modelPaths,
         Map<String, ModelPath> loopVariablePaths,
-        Set<String> referencedTemplatePaths
+        Map<String, Boolean> referencedTemplatePaths
     ) {
         this.modelPaths = List.copyOf(modelPaths);
         this.loopVariablePaths = Map.copyOf(new LinkedHashMap<>(loopVariablePaths));
-        this.referencedTemplatePaths = Set.copyOf(referencedTemplatePaths);
+        this.referencedTemplatePaths = Map.copyOf(new LinkedHashMap<>(referencedTemplatePaths));
     }
 
     public List<ModelPath> modelPaths() {
@@ -33,6 +33,10 @@ public final class TemplateInference {
     }
 
     public Set<String> referencedTemplatePaths() {
+        return referencedTemplatePaths.keySet();
+    }
+
+    public Map<String, Boolean> referencedTemplatePathsWithRecursionFlags() {
         return referencedTemplatePaths;
     }
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
@@ -57,7 +57,12 @@ public class FragmentModelInferenceService {
 
         TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames));
         InferredModel inferred = inference.toInferredModel();
-        for (String referencedTemplatePath : inference.referencedTemplatePaths()) {
+        for (Map.Entry<String, Boolean> entry : inference.referencedTemplatePathsWithRecursionFlags().entrySet()) {
+            String referencedTemplatePath = entry.getKey();
+            boolean requiresRecursion = entry.getValue();
+            if (!requiresRecursion) {
+                continue;
+            }
             if (referencedTemplatePath.equals(templatePath)) {
                 continue;
             }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -39,6 +39,7 @@ class TemplateModelExpressionAnalyzerTest {
             <div>
               <th:block th:replace="~{fragments/points-panel :: pointsPanel}"></th:block>
               <th:block th:insert="~{components/ui-alert :: error('x')}"></th:block>
+              <th:block th:replace="~{components/button :: primaryButton(label=${ctaLabel}, variant='primary')}"></th:block>
               <th:block th:replace="${dynamicRef}"></th:block>
             </div>
             """;
@@ -48,5 +49,10 @@ class TemplateModelExpressionAnalyzerTest {
         assertThat(snapshot.referencedTemplatePaths())
             .contains("fragments/points-panel", "components/ui-alert")
             .doesNotContain("dynamicRef");
+
+        assertThat(snapshot.referencedTemplatePathsWithRecursionFlags())
+            .containsEntry("fragments/points-panel", true)
+            .containsEntry("components/ui-alert", false)
+            .containsEntry("components/button", true);
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
@@ -98,4 +98,15 @@ class FragmentModelInferenceServiceTest {
             "nextPage"
         );
     }
+
+    @Test
+    void shouldNotMergeChildModelWhenStaticReferenceUsesLiteralArgumentsOnly() {
+        Map<String, Object> inferred = service.inferModel(
+            "fragments/literal-child-reference-inference-sample",
+            "literalChildReferenceInferenceSample",
+            List.of("title")
+        );
+
+        assertThat(inferred).doesNotContainKeys("label", "variant");
+    }
 }

--- a/src/test/resources/templates/components/child-model-required-inference-sample.html
+++ b/src/test/resources/templates/components/child-model-required-inference-sample.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+  <button th:fragment="child(label, variant)" th:text="${label + ':' + variant + ':' + displayName}"></button>
+</body>
+</html>

--- a/src/test/resources/templates/fragments/literal-child-reference-inference-sample.html
+++ b/src/test/resources/templates/fragments/literal-child-reference-inference-sample.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+  <section th:fragment="literalChildReferenceInferenceSample(title)">
+    <h2 th:text="${title}"></h2>
+    <th:block th:replace="~{components/child-model-required-inference-sample :: child(label='fixed', variant='primary')}"></th:block>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- prevent child template model requirements from leaking into parent inference when `th:replace`/`th:insert` arguments are literal-only
- add recursion flag metadata to template reference analysis and use it in recursive model merge
- add regression tests for both analyzer-level recursion decision and service-level merge behavior

## Details
- `TemplateModelExpressionAnalyzer` now determines whether each static template reference needs recursive model inference
- references with only literal arguments (e.g. `label='Got it'`, `variant='secondary'`) are marked as non-recursive
- `FragmentModelInferenceService` merges child inferred model only when recursion is required
- keeps recursive merge for references without arguments or with dynamic/non-literal arguments

## Verification
- `mvn -Dtest=TemplateModelExpressionAnalyzerTest,FragmentModelInferenceServiceTest test`
- `npm run test:e2e` (failed in local run due missing app on `localhost:6006`)
- `PLAYWRIGHT_BASE_URL=http://localhost:18197 npm run test:e2e` (executed; one test passed, others failed because expected sample fragments were not present in that runtime)

Closes #99
