### PR TITLE
chore(release): 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.11] - 2026-02-12
+
+- Fixed
+  - Prevented fallback/custom model inference from leaking child fragment model keys into parent fragments when `th:replace`/`th:insert` references pass literal-only arguments.
+  - Kept recursive merge for static references that have no arguments or dynamic/non-literal arguments.
+- Test
+  - Added regression coverage for recursion-flag extraction in template reference analysis and for literal-only child reference merge suppression in model inference service.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.11`.
+
+### Issues
+
+- #99 Fix fallback model inference and source snippet truncation
+
 ## [0.2.10] - 2026-02-12
 
 - Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.10</version>
+    <version>0.2.11</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.10</version>
+    <version>0.2.11</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump starter version to `0.2.11`
- bump sample app version and starter dependency to `0.2.11`
- update `CHANGELOG.md` with `0.2.11` release notes

## Verification
- `mvn -Dtest=ArchitectureConstraintArchTest test`
- `mvn -DskipTests install`
- `npm run test:e2e` (against sample app at `http://localhost:6006`)

Closes #99
