### PR TITLE
fix: remove BeanPostProcessorChecker startup warning

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -170,7 +170,7 @@ public class StorybookAutoConfiguration {
     }
 
     @Bean
-    public BeanPostProcessor thymeleafletMessageSourcePostProcessor() {
+    public static BeanPostProcessor thymeleafletMessageSourcePostProcessor() {
         return new BeanPostProcessor() {
             private final MessageSource thymeleafletMessageSource = createThymeleafletMessageSource();
 

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
@@ -1,0 +1,21 @@
+package io.github.wamukat.thymeleaflet.infrastructure.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StorybookAutoConfigurationTest {
+
+    @Test
+    void thymeleafletMessageSourcePostProcessorBeanFactoryMethod_shouldBeStatic() throws NoSuchMethodException {
+        Method method = StorybookAutoConfiguration.class.getDeclaredMethod("thymeleafletMessageSourcePostProcessor");
+
+        assertTrue(
+            Modifier.isStatic(method.getModifiers()),
+            "BeanPostProcessor factory method should be static to avoid BeanPostProcessorChecker warnings"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- make `thymeleafletMessageSourcePostProcessor` a static `@Bean` factory method in `StorybookAutoConfiguration`
- add a regression test to assert the factory method stays static

## Why
- avoid startup WARN from `PostProcessorRegistrationDelegate$BeanPostProcessorChecker` caused by a non-static `BeanPostProcessor` factory method

## Validation
- `mvn test -Dtest=StorybookAutoConfigurationTest,StorybookI18nIntegrationTest`
- `mvn -DskipTests install`
- `npm run test:e2e` (9 passed)

Closes #112
