### PR TITLE
chore(release): prepare 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.12] - 2026-02-23
+
+- Fixed
+  - Eliminated startup WARN from `PostProcessorRegistrationDelegate$BeanPostProcessorChecker` by declaring `thymeleafletMessageSourcePostProcessor` as a static `@Bean` factory method in `StorybookAutoConfiguration`.
+- Test
+  - Added regression coverage to ensure `thymeleafletMessageSourcePostProcessor` remains a static bean factory method.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.12`.
+
+### Issues
+
+- #112 Fix BeanPostProcessorChecker WARN on startup
+
 ## [0.2.11] - 2026-02-12
 
 - Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.11</version>
+    <version>0.2.12</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.11</version>
+    <version>0.2.12</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.11</version>
+            <version>0.2.12</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- prepare release `0.2.12`
- bump versions in `pom.xml` and `sample/pom.xml` to `0.2.12`
- add `0.2.12` section to `CHANGELOG.md` (Fixed/Test/Build)

## Included changes in this release
- Fixed startup WARN from `PostProcessorRegistrationDelegate$BeanPostProcessorChecker` by making `thymeleafletMessageSourcePostProcessor` static.
- Added regression test coverage for static bean factory method behavior.

## Validation
- `mvn test -Dtest=StorybookAutoConfigurationTest,StorybookI18nIntegrationTest`
- `mvn -DskipTests install`
- `npm run test:e2e` (9 passed)
- startup log check: `BeanPostProcessorChecker` warning not detected

Closes #112
