### PR TITLE
Improve sample value inference for datetime-like fields

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/ModelPath.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/ModelPath.java
@@ -1,13 +1,18 @@
 package io.github.wamukat.thymeleaflet.domain.model;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * モデル参照パスを表す値オブジェクト。
  */
 public record ModelPath(List<String> segments) {
+
+    private static final LocalDateTime SAMPLE_DATE_TIME = LocalDateTime.of(2026, 1, 1, 0, 0);
+    private static final Pattern SUFFIXED_AT_PATTERN = Pattern.compile(".*[_-]at$");
 
     public ModelPath {
         segments = List.copyOf(segments);
@@ -37,17 +42,13 @@ public record ModelPath(List<String> segments) {
     }
 
     public Object inferSampleValue() {
-        String normalized = leaf().toLowerCase(Locale.ROOT);
-        if (normalized.startsWith("is")
-            || normalized.startsWith("has")
-            || normalized.startsWith("can")
-            || normalized.startsWith("should")
-            || normalized.startsWith("enabled")
-            || normalized.startsWith("active")) {
+        String leafName = leaf();
+        String normalized = leafName.toLowerCase(Locale.ROOT);
+        if (isBooleanLike(normalized)) {
             return false;
         }
         if (normalized.contains("message")) {
-            return "Sample " + leaf();
+            return "Sample " + leafName;
         }
         if (normalized.contains("count")
             || normalized.contains("total")
@@ -63,12 +64,32 @@ public record ModelPath(List<String> segments) {
             || normalized.contains("percent")) {
             return 0;
         }
+        if (isDateTimeLike(leafName, normalized)) {
+            return SAMPLE_DATE_TIME;
+        }
         if (normalized.contains("date") || normalized.contains("time")) {
             return "2026-01-01";
         }
         if (normalized.contains("email")) {
             return "sample@example.com";
         }
-        return "Sample " + leaf();
+        return "Sample " + leafName;
+    }
+
+    private static boolean isBooleanLike(String normalized) {
+        return normalized.startsWith("is")
+            || normalized.startsWith("has")
+            || normalized.startsWith("can")
+            || normalized.startsWith("should")
+            || normalized.startsWith("enabled")
+            || normalized.startsWith("active")
+            || normalized.equals("read");
+    }
+
+    private static boolean isDateTimeLike(String leafName, String normalized) {
+        return leafName.endsWith("At")
+            || SUFFIXED_AT_PATTERN.matcher(normalized).matches()
+            || normalized.contains("datetime")
+            || normalized.contains("timestamp");
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/model/ModelPathTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/model/ModelPathTest.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.domain.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,10 +14,17 @@ class ModelPathTest {
         assertThat(ModelPath.of(List.of("root", "hasNext")).inferSampleValue()).isEqualTo(false);
         assertThat(ModelPath.of(List.of("root", "totalPoints")).inferSampleValue()).isEqualTo(0);
         assertThat(ModelPath.of(List.of("root", "createdDate")).inferSampleValue()).isEqualTo("2026-01-01");
+        assertThat(ModelPath.of(List.of("root", "publishedAt")).inferSampleValue())
+            .isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+        assertThat(ModelPath.of(List.of("root", "published_at")).inferSampleValue())
+            .isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+        assertThat(ModelPath.of(List.of("root", "published-at")).inferSampleValue())
+            .isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
         assertThat(ModelPath.of(List.of("root", "email")).inferSampleValue()).isEqualTo("sample@example.com");
         assertThat(ModelPath.of(List.of("root", "errorMessage")).inferSampleValue()).isEqualTo("Sample errorMessage");
         assertThat(ModelPath.of(List.of("root", "successMessage")).inferSampleValue()).isEqualTo("Sample successMessage");
         assertThat(ModelPath.of(List.of("root", "displayName")).inferSampleValue()).isEqualTo("Sample displayName");
+        assertThat(ModelPath.of(List.of("root", "read")).inferSampleValue()).isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Improve inferred sample model values for datetime-like keys
- Treat `*At`, `*_at`, `*-at`, `*datetime*`, and `*timestamp*` as datetime-like and infer `LocalDateTime`
- Treat `read` as boolean-like and infer `false`
- Add/extend unit tests for these inference rules

## Verification
- `./mvnw -Dtest=ModelPathTest test`
- `./mvnw -DskipTests install`
- `npm run test:e2e`

Closes #115
