### PR TITLE
Release 0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 
 ## [Unreleased]
 
+- Added
+  - TBD
+
+## [0.2.14] - 2026-03-02
+
 - Fixed
   - Replaced direct `WebMvcAutoConfiguration` type reference in `StorybookAutoConfiguration` with class-name based ordering so startup works on both Spring Boot 3 and 4.
   - Added a conditional fallback `ObjectMapper` bean in auto-configuration so Boot 4 startup does not fail when no `com.fasterxml.jackson.databind.ObjectMapper` is auto-registered.
@@ -12,6 +17,12 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
   - Updated `CookieLocaleResolver` registration to use constructor-based cookie name and `Duration` max-age so locale resolver wiring works on both Spring Framework 6 and 7.
 - Docs
   - Updated requirements docs to indicate Spring Boot `3.1+ / 4.x` support.
+- Build
+  - Updated Maven project version and sample app dependency to `0.2.14`.
+
+### Issues
+
+- #120 Fix Spring Boot 4 compatibility in starter auto-configuration
 
 ## [0.2.13] - 2026-02-26
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.13</version>
+    <version>0.2.14</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.13</version>
+    <version>0.2.14</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.13</version>
+            <version>0.2.14</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
Prepare release `0.2.14`.

## Changes
- Bump project version in `pom.xml` from `0.2.13` to `0.2.14`.
- Bump sample app version/dependency in `sample/pom.xml` from `0.2.13` to `0.2.14`.
- Finalize `CHANGELOG.md` with `0.2.14` section (2026-03-02) and move compatibility notes from Unreleased.

## Validation
- `./mvnw -q test`
- `./mvnw -q -DskipTests install`
- `cd sample && ../mvnw spring-boot:run -DskipTests` + `npm run test:e2e` (9 passed)

Closes #122
