### PR TITLE
fix: support Java Time in starter default ObjectMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.15.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
 
         <!-- Jakarta Servlet API -->
         <dependency>

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -4,6 +4,8 @@ import java.util.Locale;
 import java.time.Duration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.wamukat.thymeleaflet.domain.service.DocumentationAnalysisService;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.domain.service.StoryDataRepository;
@@ -65,7 +67,9 @@ public class StorybookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(ObjectMapper.class)
     public ObjectMapper thymeleafletObjectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Bean

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
@@ -1,11 +1,13 @@
 package io.github.wamukat.thymeleaflet.infrastructure.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
@@ -55,5 +57,16 @@ class StorybookAutoConfigurationTest {
             Arrays.asList(annotation.value()).contains(ObjectMapper.class),
             "thymeleafletObjectMapper should be conditional on ObjectMapper.class"
         );
+    }
+
+    @Test
+    @DisplayName("thymeleafletObjectMapper should serialize LocalDateTime without timestamp")
+    void thymeleafletObjectMapperBean_shouldSupportJavaTime() throws Exception {
+        StorybookAutoConfiguration configuration = new StorybookAutoConfiguration();
+        ObjectMapper objectMapper = configuration.thymeleafletObjectMapper();
+
+        String json = objectMapper.writeValueAsString(LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        assertEquals("\"2026-01-01T00:00:00\"", json);
     }
 }


### PR DESCRIPTION
## Summary
- add `jackson-datatype-jsr310` to ensure Java Time support is available in the starter
- register `JavaTimeModule` in the default `thymeleafletObjectMapper` bean
- disable timestamp date serialization for readable ISO-8601 output
- add a regression test that verifies `LocalDateTime` serialization

## Verification
- `./mvnw -q -Dtest=StorybookAutoConfigurationTest test`
- `./mvnw -q -DskipTests install`
- `npm run test:e2e` (9 passed)

Closes #124
