### PR TITLE
build: release 0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.15] - 2026-03-03
+
+- Fixed
+  - Added explicit Java Time support for the starter default `ObjectMapper` by registering `JavaTimeModule`, preventing serialization issues for `LocalDateTime` and related `java.time` types.
+  - Switched default date/time JSON serialization from timestamp form to ISO-8601 text output for predictable preview/model JSON behavior.
+- Test
+  - Added regression coverage to ensure the starter default `ObjectMapper` serializes `LocalDateTime` as ISO-8601 text.
+- Build
+  - Added `jackson-datatype-jsr310` dependency and updated Maven project/sample app versions to `0.2.15`.
+
+### Issues
+
+- #124 Fix default ObjectMapper Java Time support
+
 ## [0.2.14] - 2026-03-02
 
 - Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.14</version>
+    <version>0.2.15</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.14</version>
+    <version>0.2.15</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.14</version>
+            <version>0.2.15</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump project version to `0.2.15` in root and sample Maven modules
- add `0.2.15` release notes to `CHANGELOG.md`
- include Java Time `ObjectMapper` fix in release notes

## Verification
- `./mvnw -q -Dtest=StorybookAutoConfigurationTest test`
- `./mvnw -q -DskipTests install`
- `npm run test:e2e` (9 passed)

Closes #126
