### PR TITLE
Release 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.16] - 2026-04-25
+
+- Added
+  - Added Story YAML load diagnostics so malformed story files can be distinguished from missing story configuration.
+  - Surfaced story configuration diagnostics in the fragment main content and story preview UI with user-safe messages.
+- Changed
+  - Converted controller and service wiring to constructor injection for clearer dependencies and easier testing.
+- Docs
+  - Updated README dependency examples to the current release version.
+  - Documented the local E2E verification flow.
+- Test
+  - Added README dependency version consistency coverage.
+- Build
+  - Added a local E2E helper command that installs the starter, starts the sample app, runs Playwright, and stops the sample process.
+  - Updated Maven project and sample app versions to `0.2.16`.
+
+### Issues
+
+- #188 Fragment/story 診断を UI に表示する
+- #189 Service 層を constructor injection に統一する
+- #190 ローカル E2E を 1 コマンドで再現できるようにする
+- #191 README の依存バージョンを自動検査する
+- #192 Story YAML の読み込み失敗を診断情報として扱う
+
 ## [0.2.15] - 2026-03-03
 
 - Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,20 +20,27 @@ npm run build
 ## Local Verification
 
 For starter changes that affect the sample app or browser behavior, reinstall the
-starter locally and restart the sample before running E2E:
+starter locally and run E2E with the local helper:
+
+```bash
+npm run test:e2e:local
+```
+
+The helper starts the sample app on port `6006`, waits for it, runs Playwright,
+and stops the sample process when the command finishes.
+
+To run the steps manually:
 
 ```bash
 npm run verify:starter
 npm run sample:start
 ```
 
-In another terminal:
+Then run E2E from another terminal:
 
 ```bash
 npm run test:e2e
 ```
-
-`npm run sample:start` runs the sample app on port `6006`.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ npm install
 npm run build
 ```
 
+## Local Verification
+
+For starter changes that affect the sample app or browser behavior, reinstall the
+starter locally and restart the sample before running E2E:
+
+```bash
+npm run verify:starter
+npm run sample:start
+```
+
+In another terminal:
+
+```bash
+npm run test:e2e
+```
+
+`npm run sample:start` runs the sample app on port `6006`.
+
 ## Code Style
 
 - Prefer small, readable changes.

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.6</version>
+  <version>0.2.15</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.6")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.15")
 }
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -165,11 +165,18 @@ npm run build
 
 ## ローカル E2E 検証
 
-starter を変更した後は、ローカルに install してからサンプルアプリを再起動し、
-Playwright テストを実行します:
+starter を変更した後は、ローカル E2E ヘルパーを実行します。このコマンドは
+starter の install、サンプルアプリの起動待ち、Playwright 実行、終了時の
+サンプルプロセス停止まで行います:
 
 ```bash
 npm install
+npm run test:e2e:local
+```
+
+手動で分けて実行する場合:
+
+```bash
 npm run verify:starter
 npm run sample:start
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -163,6 +163,25 @@ npm install
 npm run build
 ```
 
+## ローカル E2E 検証
+
+starter を変更した後は、ローカルに install してからサンプルアプリを再起動し、
+Playwright テストを実行します:
+
+```bash
+npm install
+npm run verify:starter
+npm run sample:start
+```
+
+別ターミナルで E2E を実行します:
+
+```bash
+npm run test:e2e
+```
+
+サンプルアプリは `http://localhost:6006/thymeleaflet` で Thymeleaflet を提供します。
+
 ## ドキュメント
 
 以下を参照してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.15</version>
+  <version>0.2.16</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.15")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.16")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,18 @@ npm run build
 
 ## Local E2E Verification
 
-After changing the starter, install it locally and restart the sample app before
-running Playwright tests:
+After changing the starter, run the local E2E helper. It installs the starter,
+starts the sample app, waits for it to become available, runs Playwright, and
+stops the sample process when the command finishes:
 
 ```bash
 npm install
+npm run test:e2e:local
+```
+
+To run the steps manually:
+
+```bash
 npm run verify:starter
 npm run sample:start
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.15</version>
+  <version>0.2.16</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.15")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.16")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ npm install
 npm run build
 ```
 
+## Local E2E Verification
+
+After changing the starter, install it locally and restart the sample app before
+running Playwright tests:
+
+```bash
+npm install
+npm run verify:starter
+npm run sample:start
+```
+
+Then run E2E from another terminal:
+
+```bash
+npm run test:e2e
+```
+
+The sample app serves Thymeleaflet on `http://localhost:6006/thymeleaflet`.
+
 ## Documentation
 
 See:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.6</version>
+  <version>0.2.15</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.6")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.15")
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "watch": "tailwindcss -i src/main/resources/thymeleaflet/input.css -o src/main/resources/META-INF/resources/static/css/thymeleaflet.css --watch",
     "clean": "rm -f src/main/resources/META-INF/resources/static/css/thymeleaflet.css",
     "postinstall": "npm run build",
+    "verify:starter": "./mvnw -DskipTests install",
+    "sample:start": "cd sample && ../mvnw spring-boot:run -DskipTests",
     "test:e2e": "playwright test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "postinstall": "npm run build",
     "verify:starter": "./mvnw -DskipTests install",
     "sample:start": "cd sample && ../mvnw spring-boot:run -DskipTests",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:local": "node scripts/run-local-e2e.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.15</version>
+    <version>0.2.16</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.15</version>
+    <version>0.2.16</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.15</version>
+            <version>0.2.16</version>
         </dependency>
     </dependencies>
 

--- a/scripts/run-local-e2e.js
+++ b/scripts/run-local-e2e.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+
+const isWindows = process.platform === 'win32';
+const npmCommand = isWindows ? 'npm.cmd' : 'npm';
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:6006';
+const healthUrl = new URL('/thymeleaflet', baseUrl);
+
+let sampleProcess;
+let stopping = false;
+
+async function main() {
+  await runCommand(npmCommand, ['run', 'verify:starter']);
+
+  sampleProcess = spawn(npmCommand, ['run', 'sample:start'], {
+    stdio: 'inherit',
+    detached: !isWindows,
+  });
+
+  sampleProcess.on('exit', (code, signal) => {
+    if (!stopping) {
+      console.error(`sample:start exited before E2E completed (code=${code}, signal=${signal})`);
+      process.exitCode = code || 1;
+    }
+  });
+
+  await waitForSample(healthUrl, 90_000);
+  await runCommand(npmCommand, ['run', 'test:e2e']);
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} failed (code=${code}, signal=${signal})`));
+      }
+    });
+  });
+}
+
+async function waitForSample(url, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await canReach(url)) {
+      return;
+    }
+    await delay(1_000);
+  }
+  throw new Error(`Timed out waiting for sample app at ${url}`);
+}
+
+function canReach(url) {
+  return new Promise((resolve) => {
+    const request = http.get(url, (response) => {
+      response.resume();
+      resolve(response.statusCode >= 200 && response.statusCode < 300);
+    });
+    request.on('error', () => resolve(false));
+    request.setTimeout(1_000, () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stopSample() {
+  if (!sampleProcess || sampleProcess.exitCode !== null || stopping) {
+    return;
+  }
+  stopping = true;
+  if (isWindows) {
+    spawn('taskkill', ['/pid', String(sampleProcess.pid), '/t', '/f'], { stdio: 'ignore' });
+  } else {
+    process.kill(-sampleProcess.pid, 'SIGTERM');
+  }
+}
+
+process.on('SIGINT', () => {
+  stopSample();
+  process.exit(130);
+});
+
+process.on('SIGTERM', () => {
+  stopSample();
+  process.exit(143);
+});
+
+main()
+  .catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    stopSample();
+  });

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/port/inbound/story/StoryRetrievalUseCase.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/port/inbound/story/StoryRetrievalUseCase.java
@@ -29,6 +29,8 @@ public interface StoryRetrievalUseCase {
      */
     StoryListResponse getStoriesForFragment(String templatePath, String fragmentName);
 
+    Optional<StoryConfigurationDiagnostic> getStoryConfigurationDiagnostic(String templatePath);
+
     /**
      * ストーリー一覧レスポンス
      */
@@ -60,4 +62,10 @@ public interface StoryRetrievalUseCase {
         public Optional<FragmentSummary> getFragment() { return fragment; }
         public List<FragmentStoryInfo> getStories() { return stories; }
     }
+
+    record StoryConfigurationDiagnostic(
+        String code,
+        String userSafeMessage,
+        String developerMessage
+    ) {}
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/port/outbound/StoryDataPort.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/port/outbound/StoryDataPort.java
@@ -18,6 +18,13 @@ public interface StoryDataPort {
      * ストーリー設定を読み込む
      */
     Optional<StoryConfiguration> loadStoryConfiguration(String templatePath);
+
+    /**
+     * ストーリー設定読み込み時の診断情報を取得する。
+     */
+    default Optional<StoryConfigurationDiagnostic> getStoryConfigurationDiagnostic(String templatePath) {
+        return Optional.empty();
+    }
     
     /**
      * ストーリー固有のパラメータを読み込む
@@ -28,4 +35,10 @@ public interface StoryDataPort {
      * 指定されたストーリー情報を取得
      */
     Optional<FragmentStoryInfo> getStory(String templatePath, String fragmentName, String storyName);
+
+    record StoryConfigurationDiagnostic(
+        String code,
+        String userSafeMessage,
+        String developerMessage
+    ) {}
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryContentCoordinationUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryContentCoordinationUseCaseImpl.java
@@ -11,7 +11,6 @@ import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,24 +32,34 @@ import java.util.stream.Collectors;
 public class StoryContentCoordinationUseCaseImpl implements StoryContentCoordinationUseCase {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryContentCoordinationUseCaseImpl.class);
-    
-    @Autowired
-    private StoryValidationUseCase storyValidationUseCase;
-    
-    @Autowired
-    private FragmentCatalogPort fragmentCatalogPort;
-    
-    @Autowired
-    private StoryPresentationPort storyPresentationPort;
-    
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
-    
-    @Autowired
-    private StoryParameterUseCase storyParameterUseCase;
-    
-    @Autowired
-    private JavaDocLookupPort javaDocLookupPort;
+
+    private final StoryValidationUseCase storyValidationUseCase;
+
+    private final FragmentCatalogPort fragmentCatalogPort;
+
+    private final StoryPresentationPort storyPresentationPort;
+
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
+
+    private final StoryParameterUseCase storyParameterUseCase;
+
+    private final JavaDocLookupPort javaDocLookupPort;
+
+    public StoryContentCoordinationUseCaseImpl(
+        StoryValidationUseCase storyValidationUseCase,
+        FragmentCatalogPort fragmentCatalogPort,
+        StoryPresentationPort storyPresentationPort,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        StoryParameterUseCase storyParameterUseCase,
+        JavaDocLookupPort javaDocLookupPort
+    ) {
+        this.storyValidationUseCase = storyValidationUseCase;
+        this.fragmentCatalogPort = fragmentCatalogPort;
+        this.storyPresentationPort = storyPresentationPort;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.storyParameterUseCase = storyParameterUseCase;
+        this.javaDocLookupPort = javaDocLookupPort;
+    }
 
     @Override
     public StoryContentResult coordinateStoryContentSetup(StoryContentRequest request) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryContentCoordinationUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryContentCoordinationUseCaseImpl.java
@@ -88,6 +88,8 @@ public class StoryContentCoordinationUseCaseImpl implements StoryContentCoordina
             
             // 3. ストーリー一覧取得
             List<FragmentStoryInfo> stories = storyRetrievalUseCase.getStoriesForFragment(fragmentSummary);
+            storyRetrievalUseCase.getStoryConfigurationDiagnostic(request.fullTemplatePath())
+                .ifPresent(diagnostic -> request.model().addAttribute("storyConfigurationDiagnostic", diagnostic));
             
             // 4. 共通データセットアップ
             Map<String, Object> storyParameters = storyParameterUseCase.getParametersForStory(storyInfo);

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryPageCoordinationUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryPageCoordinationUseCaseImpl.java
@@ -13,7 +13,6 @@ import io.github.wamukat.thymeleaflet.domain.model.FragmentSummary;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,28 +32,39 @@ import java.util.stream.Collectors;
 public class StoryPageCoordinationUseCaseImpl implements StoryPageCoordinationUseCase {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryPageCoordinationUseCaseImpl.class);
-    
-    @Autowired
-    private FragmentDiscoveryUseCase fragmentDiscoveryUseCase;
-    
-    @Autowired
-    private FragmentStatisticsUseCase fragmentStatisticsUseCase;
-    
-    @Autowired
-    private FragmentHierarchyUseCase fragmentHierarchyUseCase;
-    
-    @Autowired
-    private MetricsUseCase metricsUseCase;
-    
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
-    
-    @Autowired
-    private FragmentPreviewUseCase fragmentPreviewUseCase;
-    
-    @Autowired
-    private FragmentCatalogPort fragmentCatalogPort;
-    
+
+    private final FragmentDiscoveryUseCase fragmentDiscoveryUseCase;
+
+    private final FragmentStatisticsUseCase fragmentStatisticsUseCase;
+
+    private final FragmentHierarchyUseCase fragmentHierarchyUseCase;
+
+    private final MetricsUseCase metricsUseCase;
+
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
+
+    private final FragmentPreviewUseCase fragmentPreviewUseCase;
+
+    private final FragmentCatalogPort fragmentCatalogPort;
+
+    public StoryPageCoordinationUseCaseImpl(
+        FragmentDiscoveryUseCase fragmentDiscoveryUseCase,
+        FragmentStatisticsUseCase fragmentStatisticsUseCase,
+        FragmentHierarchyUseCase fragmentHierarchyUseCase,
+        MetricsUseCase metricsUseCase,
+        StoryRetrievalUseCase storyRetrievalUseCase,
+        FragmentPreviewUseCase fragmentPreviewUseCase,
+        FragmentCatalogPort fragmentCatalogPort
+    ) {
+        this.fragmentDiscoveryUseCase = fragmentDiscoveryUseCase;
+        this.fragmentStatisticsUseCase = fragmentStatisticsUseCase;
+        this.fragmentHierarchyUseCase = fragmentHierarchyUseCase;
+        this.metricsUseCase = metricsUseCase;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.fragmentPreviewUseCase = fragmentPreviewUseCase;
+        this.fragmentCatalogPort = fragmentCatalogPort;
+    }
+
     @Override
     public StoryPageResult coordinateStoryPageSetup(StoryPageRequest request) {
         logger.info("=== StoryPageCoordination START ===");

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryPageCoordinationUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/coordination/StoryPageCoordinationUseCaseImpl.java
@@ -111,6 +111,8 @@ public class StoryPageCoordinationUseCaseImpl implements StoryPageCoordinationUs
                     request.storyName()
                 );
             }
+            storyRetrievalUseCase.getStoryConfigurationDiagnostic(request.fullTemplatePath())
+                .ifPresent(diagnostic -> request.model().addAttribute("storyConfigurationDiagnostic", diagnostic));
             
             // 3. Modelに統合結果を設定 (Domain形式のFragmentSummaryを設定)
             request.model().addAttribute("allFragments", allFragments); // Domain形式のFragmentSummary

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/fragment/FragmentDiscoveryUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/fragment/FragmentDiscoveryUseCaseImpl.java
@@ -2,7 +2,6 @@ package io.github.wamukat.thymeleaflet.application.service.fragment;
 
 import io.github.wamukat.thymeleaflet.application.port.inbound.fragment.FragmentDiscoveryUseCase;
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentCatalogPort;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,9 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Transactional(readOnly = true)
 public class FragmentDiscoveryUseCaseImpl implements FragmentDiscoveryUseCase {
-    
-    @Autowired
-    private FragmentCatalogPort fragmentCatalogPort;
+
+    private final FragmentCatalogPort fragmentCatalogPort;
+
+    public FragmentDiscoveryUseCaseImpl(FragmentCatalogPort fragmentCatalogPort) {
+        this.fragmentCatalogPort = fragmentCatalogPort;
+    }
 
     @Override
     public FragmentDetailResponse discoverFragment(String templatePath, String fragmentName) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/preview/FragmentPreviewUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/preview/FragmentPreviewUseCaseImpl.java
@@ -8,7 +8,6 @@ import io.github.wamukat.thymeleaflet.application.port.outbound.JavaDocLookupPor
 import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
@@ -27,18 +26,26 @@ import java.util.Map;
 public class FragmentPreviewUseCaseImpl implements FragmentPreviewUseCase {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentPreviewUseCaseImpl.class);
-    
-    @Autowired
-    private StoryContentCoordinationUseCase storyContentCoordinationUseCase;
-    
-    @Autowired
-    private JavaDocLookupPort javaDocLookupPort;
-    
-    @Autowired
-    private ObjectMapper objectMapper;
 
-    @Autowired
-    private FragmentDependencyPort fragmentDependencyPort;
+    private final StoryContentCoordinationUseCase storyContentCoordinationUseCase;
+
+    private final JavaDocLookupPort javaDocLookupPort;
+
+    private final ObjectMapper objectMapper;
+
+    private final FragmentDependencyPort fragmentDependencyPort;
+
+    public FragmentPreviewUseCaseImpl(
+        StoryContentCoordinationUseCase storyContentCoordinationUseCase,
+        JavaDocLookupPort javaDocLookupPort,
+        ObjectMapper objectMapper,
+        FragmentDependencyPort fragmentDependencyPort
+    ) {
+        this.storyContentCoordinationUseCase = storyContentCoordinationUseCase;
+        this.javaDocLookupPort = javaDocLookupPort;
+        this.objectMapper = objectMapper;
+        this.fragmentDependencyPort = fragmentDependencyPort;
+    }
 
     @Override
     public PageSetupResponse setupStoryContentData(PageSetupCommand command) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryParameterUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryParameterUseCaseImpl.java
@@ -5,7 +5,6 @@ import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import io.github.wamukat.thymeleaflet.domain.service.StoryParameterDomainService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,9 +23,12 @@ import java.util.Map;
 public class StoryParameterUseCaseImpl implements StoryParameterUseCase {
     
     private static final Logger logger = LoggerFactory.getLogger(StoryParameterUseCaseImpl.class);
-    
-    @Autowired
-    private StoryParameterDomainService storyParameterDomainService;
+
+    private final StoryParameterDomainService storyParameterDomainService;
+
+    public StoryParameterUseCaseImpl(StoryParameterDomainService storyParameterDomainService) {
+        this.storyParameterDomainService = storyParameterDomainService;
+    }
 
     @Override
     public Map<String, Object> getParametersForStory(FragmentStoryInfo storyInfo) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
@@ -117,4 +117,14 @@ public class StoryRetrievalUseCaseImpl implements StoryRetrievalUseCase {
             .orElseGet(StoryListResponse::failure);
     }
 
+    @Override
+    public Optional<StoryConfigurationDiagnostic> getStoryConfigurationDiagnostic(String templatePath) {
+        return storyDataPort.getStoryConfigurationDiagnostic(templatePath)
+            .map(diagnostic -> new StoryConfigurationDiagnostic(
+                diagnostic.code(),
+                diagnostic.userSafeMessage(),
+                diagnostic.developerMessage()
+            ));
+    }
+
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
@@ -9,7 +9,6 @@ import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryConfigurat
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryGroup;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryItem;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryPreview;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +28,15 @@ import java.util.Optional;
 public class StoryRetrievalUseCaseImpl implements StoryRetrievalUseCase {
 
     private static final String CUSTOM_STORY_NAME = "custom";
-    
-    @Autowired
-    private StoryDataPort storyDataPort;
+
+    private final StoryDataPort storyDataPort;
+
+    private final FragmentCatalogPort fragmentCatalogPort;
+
+    public StoryRetrievalUseCaseImpl(StoryDataPort storyDataPort, FragmentCatalogPort fragmentCatalogPort) {
+        this.storyDataPort = storyDataPort;
+        this.fragmentCatalogPort = fragmentCatalogPort;
+    }
 
     @Override
     public Optional<FragmentStoryInfo> getStory(String templatePath, String fragmentName, String storyName) {
@@ -112,7 +117,4 @@ public class StoryRetrievalUseCaseImpl implements StoryRetrievalUseCase {
             .orElseGet(StoryListResponse::failure);
     }
 
-    @Autowired
-    private FragmentCatalogPort fragmentCatalogPort;
-    
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryValidationUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryValidationUseCaseImpl.java
@@ -2,7 +2,6 @@ package io.github.wamukat.thymeleaflet.application.service.story;
 
 import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryValidationUseCase;
 import io.github.wamukat.thymeleaflet.application.port.outbound.StoryDataPort;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,9 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Transactional(readOnly = true)
 public class StoryValidationUseCaseImpl implements StoryValidationUseCase {
-    
-    @Autowired
-    private StoryDataPort storyDataPort;
+
+    private final StoryDataPort storyDataPort;
+
+    public StoryValidationUseCaseImpl(StoryDataPort storyDataPort) {
+        this.storyDataPort = storyDataPort;
+    }
 
     @Override
     public StoryValidationResult validateStory(StoryValidationCommand command) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -4,7 +4,6 @@ import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
@@ -35,15 +34,22 @@ public class FragmentDiscoveryService {
 
     private volatile boolean cacheInitialized;
     private volatile List<FragmentInfo> cachedFragments = List.of();
-    
-    @Autowired
-    private FragmentDomainService fragmentDomainService;
-    
-    @Autowired
-    private ResolvedStorybookConfig storybookConfig;
 
-    @Autowired
-    private FragmentSignatureParser fragmentSignatureParser;
+    private final FragmentDomainService fragmentDomainService;
+
+    private final ResolvedStorybookConfig storybookConfig;
+
+    private final FragmentSignatureParser fragmentSignatureParser;
+
+    public FragmentDiscoveryService(
+        FragmentDomainService fragmentDomainService,
+        ResolvedStorybookConfig storybookConfig,
+        FragmentSignatureParser fragmentSignatureParser
+    ) {
+        this.fragmentDomainService = fragmentDomainService;
+        this.storybookConfig = storybookConfig;
+        this.fragmentSignatureParser = fragmentSignatureParser;
+    }
     
     /**
      * テンプレートディレクトリから全フラグメントを発見

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapter.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapter.java
@@ -52,6 +52,18 @@ public class StoryDataAdapter implements StoryDataPort {
             return Optional.empty();
         }
     }
+
+    @Override
+    public Optional<StoryConfigurationDiagnostic> getStoryConfigurationDiagnostic(String templatePath) {
+        YamlStoryConfigurationLoader.StoryConfigurationLoadResult result =
+            yamlStoryConfigurationLoader.loadStoryConfigurationWithDiagnostics(templatePath);
+        return result.diagnostic()
+            .map(diagnostic -> new StoryConfigurationDiagnostic(
+                diagnostic.code(),
+                diagnostic.userSafeMessage(),
+                diagnostic.developerMessage()
+            ));
+    }
     
     @Override
     public Map<String, Object> loadStoryParameters(FragmentStoryInfo storyInfo) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapter.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapter.java
@@ -9,7 +9,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery.FragmentD
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSummaryMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -29,15 +28,19 @@ public class StoryDataAdapter implements StoryDataPort {
     private static final Logger logger = LoggerFactory.getLogger(StoryDataAdapter.class);
 
     private final YamlStoryConfigurationLoader yamlStoryConfigurationLoader;
-    
-    @Autowired
-    private FragmentDiscoveryService fragmentDiscoveryService;
-    
-    @Autowired
-    private FragmentSummaryMapper fragmentSummaryMapper;
-    
-    public StoryDataAdapter(YamlStoryConfigurationLoader yamlStoryConfigurationLoader) {
+
+    private final FragmentDiscoveryService fragmentDiscoveryService;
+
+    private final FragmentSummaryMapper fragmentSummaryMapper;
+
+    public StoryDataAdapter(
+        YamlStoryConfigurationLoader yamlStoryConfigurationLoader,
+        FragmentDiscoveryService fragmentDiscoveryService,
+        FragmentSummaryMapper fragmentSummaryMapper
+    ) {
         this.yamlStoryConfigurationLoader = yamlStoryConfigurationLoader;
+        this.fragmentDiscoveryService = fragmentDiscoveryService;
+        this.fragmentSummaryMapper = fragmentSummaryMapper;
     }
     
     @Override

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/YamlStoryConfigurationLoader.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/YamlStoryConfigurationLoader.java
@@ -45,9 +45,16 @@ public class YamlStoryConfigurationLoader {
      * Infrastructure技術的責任: ファイル読み込み・YAML解析のみ
      */
     public Optional<StoryConfiguration> loadStoryConfiguration(String templatePath) {
+        return loadStoryConfigurationWithDiagnostics(templatePath).configuration();
+    }
+
+    /**
+     * Story設定を読み込み、未定義fallbackと読み込み/解析失敗を区別できる結果を返す。
+     */
+    public StoryConfigurationLoadResult loadStoryConfigurationWithDiagnostics(String templatePath) {
         if (templatePath.isBlank()) {
             logger.debug("Template path is empty");
-            return Optional.empty();
+            return StoryConfigurationLoadResult.missing("");
         }
 
         String storyFilePath = STORY_BASE_PATH + templatePath + ".stories.yml";
@@ -56,7 +63,7 @@ public class YamlStoryConfigurationLoader {
             Resource resource = resourceLoader.getResource(storyFilePath);
             if (!resource.exists()) {
                 logger.debug("Story file not found: {}", storyFilePath);
-                return Optional.empty();
+                return StoryConfigurationLoadResult.missing(storyFilePath);
             }
 
             try (InputStream inputStream = resource.getInputStream()) {
@@ -65,18 +72,21 @@ public class YamlStoryConfigurationLoader {
                 Optional<StoryConfiguration> configuration = Optional.ofNullable(config);
                 if (configuration.isEmpty()) {
                     logger.warn("YAML parsing resulted in null configuration: {}", storyFilePath);
+                    return StoryConfigurationLoadResult.failure(StoryConfigurationDiagnostic.nullConfiguration(storyFilePath));
                 } else {
                     logger.debug("Successfully loaded story configuration from: {}", storyFilePath);
                 }
-                return configuration;
+                return StoryConfigurationLoadResult.loaded(configuration.orElseThrow());
             }
 
         } catch (IOException e) {
-            logger.warn("Failed to load story file {}: {}", storyFilePath, e.getMessage(), e);
-            return Optional.empty();
+            StoryConfigurationDiagnostic diagnostic = StoryConfigurationDiagnostic.loadFailed(storyFilePath, e);
+            logger.warn("{}: {}", diagnostic.userSafeMessage(), diagnostic.developerMessage());
+            return StoryConfigurationLoadResult.failure(diagnostic);
         } catch (Exception e) {
-            logger.error("Unexpected error loading story file {}: {}", storyFilePath, e.getMessage(), e);
-            return Optional.empty();
+            StoryConfigurationDiagnostic diagnostic = StoryConfigurationDiagnostic.unexpectedFailure(storyFilePath, e);
+            logger.error("{}: {}", diagnostic.userSafeMessage(), diagnostic.developerMessage(), e);
+            return StoryConfigurationLoadResult.failure(diagnostic);
         }
     }
 
@@ -123,6 +133,76 @@ public class YamlStoryConfigurationLoader {
         } catch (Exception e) {
             logger.debug("Error getting last modified time for {}: {}", storyFilePath, e.getMessage());
             return Optional.empty();
+        }
+    }
+
+    public enum StoryConfigurationLoadStatus {
+        LOADED,
+        MISSING,
+        FAILED
+    }
+
+    public record StoryConfigurationDiagnostic(
+        String code,
+        String storyFilePath,
+        String userSafeMessage,
+        String developerMessage
+    ) {
+        private static StoryConfigurationDiagnostic nullConfiguration(String storyFilePath) {
+            return new StoryConfigurationDiagnostic(
+                "STORY_YAML_NULL_CONFIGURATION",
+                storyFilePath,
+                "Story YAML was found but did not produce a valid configuration.",
+                "YAML parser returned null configuration for " + storyFilePath
+            );
+        }
+
+        private static StoryConfigurationDiagnostic loadFailed(String storyFilePath, IOException exception) {
+            return new StoryConfigurationDiagnostic(
+                "STORY_YAML_LOAD_FAILED",
+                storyFilePath,
+                "Story YAML was found but could not be loaded or parsed.",
+                exception.getClass().getSimpleName() + ": " + exception.getMessage()
+            );
+        }
+
+        private static StoryConfigurationDiagnostic unexpectedFailure(String storyFilePath, Exception exception) {
+            return new StoryConfigurationDiagnostic(
+                "STORY_YAML_UNEXPECTED_FAILURE",
+                storyFilePath,
+                "Story YAML was found but an unexpected error occurred while loading it.",
+                exception.getClass().getSimpleName() + ": " + exception.getMessage()
+            );
+        }
+    }
+
+    public record StoryConfigurationLoadResult(
+        StoryConfigurationLoadStatus status,
+        Optional<StoryConfiguration> configuration,
+        Optional<StoryConfigurationDiagnostic> diagnostic
+    ) {
+        private static StoryConfigurationLoadResult loaded(StoryConfiguration configuration) {
+            return new StoryConfigurationLoadResult(
+                StoryConfigurationLoadStatus.LOADED,
+                Optional.of(configuration),
+                Optional.empty()
+            );
+        }
+
+        private static StoryConfigurationLoadResult missing(String storyFilePath) {
+            return new StoryConfigurationLoadResult(
+                StoryConfigurationLoadStatus.MISSING,
+                Optional.empty(),
+                Optional.empty()
+            );
+        }
+
+        private static StoryConfigurationLoadResult failure(StoryConfigurationDiagnostic diagnostic) {
+            return new StoryConfigurationLoadResult(
+                StoryConfigurationLoadStatus.FAILED,
+                Optional.empty(),
+                Optional.of(diagnostic)
+            );
         }
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/FragmentListController.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/FragmentListController.java
@@ -6,7 +6,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.web.service.FragmentMainCon
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.ThymeleafletVersionResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,17 +24,21 @@ public class FragmentListController {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentListController.class);
 
-    @Autowired
-    private FragmentDiscoveryService fragmentDiscoveryService;
-    
-    @Autowired
-    private FragmentMainContentService fragmentMainContentService;
+    private final FragmentDiscoveryService fragmentDiscoveryService;
+    private final FragmentMainContentService fragmentMainContentService;
+    private final ThymeleafletVersionResolver thymeleafletVersionResolver;
+    private final ResolvedStorybookConfig resolvedStorybookConfig;
 
-    @Autowired
-    private ThymeleafletVersionResolver thymeleafletVersionResolver;
-
-    @Autowired
-    private ResolvedStorybookConfig resolvedStorybookConfig;
+    public FragmentListController(
+            FragmentDiscoveryService fragmentDiscoveryService,
+            FragmentMainContentService fragmentMainContentService,
+            ThymeleafletVersionResolver thymeleafletVersionResolver,
+            ResolvedStorybookConfig resolvedStorybookConfig) {
+        this.fragmentDiscoveryService = fragmentDiscoveryService;
+        this.fragmentMainContentService = fragmentMainContentService;
+        this.thymeleafletVersionResolver = thymeleafletVersionResolver;
+        this.resolvedStorybookConfig = resolvedStorybookConfig;
+    }
     
     /**
      * Storybookメインエントリーポイント - フラグメント一覧ページ (プレースホルダ最適化版)

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/StoryPreviewController.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/StoryPreviewController.java
@@ -6,7 +6,6 @@ import io.github.wamukat.thymeleaflet.infrastructure.web.service.SecurePathConve
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.StoryPreviewService;
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.StoryContentService;
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.ThymeleafletVersionResolver;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -26,23 +25,27 @@ import java.util.Optional;
 @Controller
 public class StoryPreviewController {
     
-    @Autowired
-    private StoryPreviewService storyPreviewService;
-    
-    @Autowired
-    private StoryContentService storyContentService;
+    private final StoryPreviewService storyPreviewService;
+    private final StoryContentService storyContentService;
+    private final StoryRetrievalUseCase storyRetrievalUseCase;
+    private final SecurePathConversionService securePathConversionService;
+    private final ThymeleafletVersionResolver thymeleafletVersionResolver;
+    private final String basePath;
 
-    @Autowired
-    private StoryRetrievalUseCase storyRetrievalUseCase;
-
-    @Autowired
-    private SecurePathConversionService securePathConversionService;
-
-    @Autowired
-    private ThymeleafletVersionResolver thymeleafletVersionResolver;
-
-    @Value("${thymeleaflet.base-path:/thymeleaflet}")
-    private String basePath = "/thymeleaflet";
+    public StoryPreviewController(
+            StoryPreviewService storyPreviewService,
+            StoryContentService storyContentService,
+            StoryRetrievalUseCase storyRetrievalUseCase,
+            SecurePathConversionService securePathConversionService,
+            ThymeleafletVersionResolver thymeleafletVersionResolver,
+            @Value("${thymeleaflet.base-path:/thymeleaflet}") String basePath) {
+        this.storyPreviewService = storyPreviewService;
+        this.storyContentService = storyContentService;
+        this.storyRetrievalUseCase = storyRetrievalUseCase;
+        this.securePathConversionService = securePathConversionService;
+        this.thymeleafletVersionResolver = thymeleafletVersionResolver;
+        this.basePath = basePath;
+    }
     
     /**
      * 個別ストーリープレビューページ（統一テンプレート構造を使用）

--- a/src/main/resources/templates/thymeleaflet/fragments/main-content.html
+++ b/src/main/resources/templates/thymeleaflet/fragments/main-content.html
@@ -36,6 +36,13 @@
                     This fragment declaration may not be fully supported.
                 </div>
             </div>
+            <div th:if="${storyConfigurationDiagnostic != null}"
+                 class="mt-3 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-900">
+                <div class="font-semibold" th:text="${storyConfigurationDiagnostic.code}">STORY_YAML_LOAD_FAILED</div>
+                <div th:text="${storyConfigurationDiagnostic.userSafeMessage}">
+                    Story YAML was found but could not be loaded.
+                </div>
+            </div>
         </div>
         <!-- ストーリー選択 -->
         <div class="card-thymeleaflet">

--- a/src/main/resources/templates/thymeleaflet/story-preview.html
+++ b/src/main/resources/templates/thymeleaflet/story-preview.html
@@ -113,6 +113,13 @@
                                     This fragment declaration may not be fully supported.
                                 </div>
                             </div>
+                            <div th:if="${storyConfigurationDiagnostic != null}"
+                                 class="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-900">
+                                <div class="font-semibold" th:text="${storyConfigurationDiagnostic.code}">STORY_YAML_LOAD_FAILED</div>
+                                <div th:text="${storyConfigurationDiagnostic.userSafeMessage}">
+                                    Story YAML was found but could not be loaded.
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/test/java/io/github/wamukat/thymeleaflet/documentation/ReadmeVersionConsistencyTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/documentation/ReadmeVersionConsistencyTest.java
@@ -1,0 +1,62 @@
+package io.github.wamukat.thymeleaflet.documentation;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReadmeVersionConsistencyTest {
+
+    private static final Path PROJECT_ROOT = Path.of("").toAbsolutePath();
+    private static final String GROUP_ID = "io.github.wamukat";
+    private static final String ARTIFACT_ID = "thymeleaflet-spring-boot-starter";
+
+    @Test
+    void readmeDependencyExamplesUseProjectVersion() throws Exception {
+        String projectVersion = readProjectVersion();
+
+        assertReadmeUsesVersion(PROJECT_ROOT.resolve("README.md"), projectVersion);
+        assertReadmeUsesVersion(PROJECT_ROOT.resolve("README.ja.md"), projectVersion);
+    }
+
+    private static String readProjectVersion() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        Document document = factory.newDocumentBuilder().parse(PROJECT_ROOT.resolve("pom.xml").toFile());
+        Element project = document.getDocumentElement();
+
+        for (Node child = project.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child.getNodeType() == Node.ELEMENT_NODE && "version".equals(child.getNodeName())) {
+                return Objects.requireNonNull(child.getTextContent()).trim();
+            }
+        }
+        throw new IllegalStateException("Project version not found in pom.xml");
+    }
+
+    private static void assertReadmeUsesVersion(Path readmePath, String projectVersion) throws Exception {
+        String readme = Files.readString(readmePath);
+        assertThat(readme)
+            .as("%s Maven dependency version", readmePath.getFileName())
+            .contains("""
+                <dependency>
+                  <groupId>%s</groupId>
+                  <artifactId>%s</artifactId>
+                  <version>%s</version>
+                </dependency>
+                """.formatted(GROUP_ID, ARTIFACT_ID, projectVersion));
+        assertThat(readme)
+            .as("%s Gradle dependency version", readmePath.getFileName())
+            .contains("implementation(\"" + GROUP_ID + ":" + ARTIFACT_ID + ":" + projectVersion + "\")");
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapterTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/StoryDataAdapterTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -41,9 +40,11 @@ class StoryDataAdapterTest {
 
     @BeforeEach
     void setUp() {
-        adapter = new StoryDataAdapter(yamlStoryConfigurationLoader);
-        ReflectionTestUtils.setField(adapter, "fragmentDiscoveryService", fragmentDiscoveryService);
-        ReflectionTestUtils.setField(adapter, "fragmentSummaryMapper", fragmentSummaryMapper);
+        adapter = new StoryDataAdapter(
+            yamlStoryConfigurationLoader,
+            fragmentDiscoveryService,
+            fragmentSummaryMapper
+        );
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/YamlStoryConfigurationLoaderTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/persistence/YamlStoryConfigurationLoaderTest.java
@@ -109,6 +109,50 @@ class YamlStoryConfigurationLoaderTest {
     }
 
     @Test
+    @DisplayName("存在しないYAMLはmissing診断として扱う")
+    void shouldReturnMissingResultForNonexistentFile() throws IOException {
+        // Given
+        String templatePath = "templates/nonexistent/component";
+
+        when(mockResourceLoader.getResource(any(String.class))).thenReturn(mockResource);
+        when(mockResource.exists()).thenReturn(false);
+
+        // When
+        YamlStoryConfigurationLoader.StoryConfigurationLoadResult result =
+            loader.loadStoryConfigurationWithDiagnostics(templatePath);
+
+        // Then
+        assertThat(result.status()).isEqualTo(YamlStoryConfigurationLoader.StoryConfigurationLoadStatus.MISSING);
+        assertThat(result.configuration()).isEmpty();
+        assertThat(result.diagnostic()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("存在するYAMLの読み込み失敗は診断情報として保持する")
+    void shouldReturnDiagnosticForExistingYamlLoadFailure() throws IOException {
+        // Given
+        String templatePath = "templates/broken/component";
+
+        when(mockResourceLoader.getResource(any(String.class))).thenReturn(mockResource);
+        when(mockResource.exists()).thenReturn(true);
+        when(mockResource.getInputStream()).thenThrow(new IOException("broken yaml stream"));
+
+        // When
+        YamlStoryConfigurationLoader.StoryConfigurationLoadResult result =
+            loader.loadStoryConfigurationWithDiagnostics(templatePath);
+
+        // Then
+        assertThat(result.status()).isEqualTo(YamlStoryConfigurationLoader.StoryConfigurationLoadStatus.FAILED);
+        assertThat(result.configuration()).isEmpty();
+        assertThat(result.diagnostic()).isPresent();
+        YamlStoryConfigurationLoader.StoryConfigurationDiagnostic diagnostic = result.diagnostic().orElseThrow();
+        assertThat(diagnostic.code()).isEqualTo("STORY_YAML_LOAD_FAILED");
+        assertThat(diagnostic.storyFilePath()).contains(templatePath + ".stories.yml");
+        assertThat(diagnostic.userSafeMessage()).contains("could not be loaded or parsed");
+        assertThat(diagnostic.developerMessage()).contains("broken yaml stream");
+    }
+
+    @Test
     @DisplayName("nullのtemplatePathの場合はNullPointerExceptionを送出する")
     @SuppressWarnings("NullAway")
     void shouldHandleNullTemplatePath() {


### PR DESCRIPTION
## Summary

Prepare Thymeleaflet 0.2.16 release.

## Changes

- Update root and sample Maven versions to 0.2.16
- Update README dependency examples to 0.2.16
- Add 0.2.16 CHANGELOG entry for diagnostics UI, YAML load diagnostics, constructor injection, local E2E helper, and README version consistency coverage

## Verification

- `./mvnw test -q` passed
- `npm run test:e2e:local` passed: 9/9 E2E tests
- `lsof -n -iTCP:6006 -sTCP:LISTEN` confirmed no sample app listener remains

## Issues

Closes: N/A
Kanban: #188, #189, #190, #191, #192

## Release

After merge to `main`, tag `v0.2.16` and run the Maven Central release flow from `RELEASE.md`.