### PR TITLE
Fix @example parsing for th:block and no-arg fragments

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
@@ -38,7 +38,7 @@ public class JavaDocAnalyzer {
     );
     
     private static final Pattern EXAMPLE_PATTERN = Pattern.compile(
-        "@example\\s+.*?<(div|span)[^>]*th:replace=\"~\\{([^}]+?)\\s*::\\s*([^\\(\\}]+?)\\(([^)]*)\\)\\}\"[^>]*></(div|span)>",
+        "@example\\s+.*?<(?:div|span|th:block)[^>]*th:replace=\"~\\{([^}]+?)\\s*::\\s*([^\\(\\}]+?)\\s*(?:\\(([^)]*)\\))?\\s*\\}\"[^>]*></(?:div|span|th:block)>",
         Pattern.MULTILINE | Pattern.DOTALL
     );
     
@@ -175,9 +175,9 @@ public class JavaDocAnalyzer {
         
         Matcher exampleMatcher = EXAMPLE_PATTERN.matcher(javadocContent);
         while (exampleMatcher.find()) {
-            String templatePath = exampleMatcher.group(2).trim();
-            String fragmentName = exampleMatcher.group(3).trim();
-            String argumentsStr = exampleMatcher.group(4);
+            String templatePath = exampleMatcher.group(1).trim();
+            String fragmentName = exampleMatcher.group(2).trim();
+            String argumentsStr = Optional.ofNullable(exampleMatcher.group(3)).orElse("");
             
             List<String> arguments = parseArguments(argumentsStr);
             examples.add(ExampleInfo.of(templatePath, fragmentName, arguments));

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
@@ -270,4 +270,37 @@ class JavaDocAnalyzerTest {
         assertThat(examples.get(1).getFragmentName()).isEqualTo("primary-button");
         assertThat(examples.get(1).getArguments()).contains("'Cancel'", "'secondary'");
     }
+
+    @Test
+    @DisplayName("@exampleタグでth:blockと引数なしフラグメントを解析できる")
+    void shouldParseThBlockAndNoArgumentExamples() {
+        // Given
+        String htmlContent = """
+            <!--
+            /**
+             * Examples using Thymeleaf block and no-argument fragment syntax
+             * @example <th:block th:replace="~{components/status :: statusBadge(label='Ready')}"></th:block>
+             * @example <div th:replace="~{components/header :: responsiveHeader}"></div>
+             */
+            -->
+            <div th:fragment="responsiveHeader">Header</div>
+            """;
+
+        // When
+        List<JavaDocAnalyzer.JavaDocInfo> result = analyzer.analyzeJavaDocFromHtml(htmlContent);
+
+        // Then
+        assertThat(result).hasSize(1);
+
+        List<JavaDocAnalyzer.ExampleInfo> examples = result.get(0).getExamples();
+        assertThat(examples).hasSize(2);
+
+        assertThat(examples.get(0).getTemplatePath()).isEqualTo("components/status");
+        assertThat(examples.get(0).getFragmentName()).isEqualTo("statusBadge");
+        assertThat(examples.get(0).getArguments()).containsExactly("label='Ready'");
+
+        assertThat(examples.get(1).getTemplatePath()).isEqualTo("components/header");
+        assertThat(examples.get(1).getFragmentName()).isEqualTo("responsiveHeader");
+        assertThat(examples.get(1).getArguments()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

Fix JavaDoc `@example` parsing so it recognizes Thymeleaf `<th:block>` replacement examples and no-argument fragment references such as `:: responsiveHeader`.

Closes #130

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=JavaDocAnalyzerTest test`
- `./mvnw -q -Dfrontend.skip=true test`
- `./mvnw -q -Dfrontend.skip=true -DskipTests install`
- `npm run test:e2e`
