### PR TITLE
Disable Thymeleaflet cache with Thymeleaf dev cache

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,8 @@ thymeleaflet:
 - JS を使う場合は `resources.scripts` に登録し、`preview.wrapper` で必要なDOM構造を整えてください。
   - 例: `<div data-theme=\"light\">{{content}}</div>`
 - `cache.enabled` はフラグメント探索・JavaDoc解析・依存解析のメモリキャッシュを有効化します。
+- `spring.thymeleaf.cache=false` かつ `thymeleaflet.cache.enabled` が未指定の場合、開発中のテンプレート変更が
+  反映されるよう Thymeleaflet の内部キャッシュも自動的に無効化します。
 - `cache.preload` は起動時にキャッシュをウォームアップします（低CPU環境向け）。
 - CSP はプレビューで外部 JS/CSS を使えるよう意図的に緩めています。信頼できる環境でのみ利用してください。
 - プレビュー iframe は same-origin を許可しているため、Cookie / localStorage / 認証付きAPIが動作します。

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ thymeleaflet:
   so the preview matches app behavior.
   Example: `<div data-theme="light">{{content}}</div>`
 - `cache.enabled` enables in-memory caching for fragment discovery, JavaDoc parsing, and dependency analysis.
+- When `spring.thymeleaf.cache=false` and `thymeleaflet.cache.enabled` is not set, Thymeleaflet also disables its
+  internal caches so template-only edits are reflected during development.
 - `cache.preload` warms the caches at application startup (useful for low-CPU demo environments).
 - CSP is intentionally permissive to allow external JS/CSS in previews. Use only in trusted environments.
 - Preview iframes allow same-origin so cookies/localStorage and authenticated API calls work.

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfig.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfig.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * 実行時に利用する非null前提の設定オブジェクト。
@@ -41,7 +42,16 @@ public final class ResolvedStorybookConfig {
     }
 
     public static ResolvedStorybookConfig from(StorybookProperties raw) {
+        return from(raw, Optional.empty());
+    }
+
+    public static ResolvedStorybookConfig from(StorybookProperties raw, boolean cacheEnabled) {
+        return from(raw, Optional.of(cacheEnabled));
+    }
+
+    private static ResolvedStorybookConfig from(StorybookProperties raw, Optional<Boolean> cacheEnabledOverride) {
         Objects.requireNonNull(raw, "raw cannot be null");
+        Objects.requireNonNull(cacheEnabledOverride, "cacheEnabledOverride cannot be null");
         String basePath = normalizeBasePath(raw.getBasePath());
         if (!DEFAULT_BASE_PATH.equals(basePath)) {
             throw new IllegalArgumentException(
@@ -57,7 +67,8 @@ public final class ResolvedStorybookConfig {
             rawResources != null ? rawResources : new StorybookProperties.ResourceConfig()
         );
         CacheConfig cache = CacheConfig.from(
-            rawCache != null ? rawCache : new StorybookProperties.CacheConfig()
+            rawCache != null ? rawCache : new StorybookProperties.CacheConfig(),
+            cacheEnabledOverride
         );
         PreviewConfig preview = PreviewConfig.from(
             rawPreview != null ? rawPreview : new StorybookProperties.PreviewConfig()
@@ -163,8 +174,8 @@ public final class ResolvedStorybookConfig {
             this.preload = preload;
         }
 
-        private static CacheConfig from(StorybookProperties.CacheConfig source) {
-            return new CacheConfig(source.isEnabled(), source.isPreload());
+        private static CacheConfig from(StorybookProperties.CacheConfig source, Optional<Boolean> enabledOverride) {
+            return new CacheConfig(enabledOverride.orElse(source.isEnabled()), source.isPreload());
         }
 
         public boolean isEnabled() {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.configuration;
 
 import java.time.Duration;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.env.Environment;
 import org.springframework.core.annotation.Order;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -63,8 +65,22 @@ public class StorybookAutoConfiguration {
     }
 
     @Bean
-    public ResolvedStorybookConfig resolvedStorybookConfig(StorybookProperties storybookProperties) {
+    public ResolvedStorybookConfig resolvedStorybookConfig(StorybookProperties storybookProperties, Environment environment) {
+        Optional<Boolean> cacheEnabled = resolveCacheEnabled(environment);
+        if (cacheEnabled.isPresent()) {
+            return ResolvedStorybookConfig.from(storybookProperties, cacheEnabled.orElseThrow());
+        }
         return ResolvedStorybookConfig.from(storybookProperties);
+    }
+
+    private Optional<Boolean> resolveCacheEnabled(Environment environment) {
+        if (environment.containsProperty("thymeleaflet.cache.enabled")) {
+            return Optional.empty();
+        }
+        if ("false".equalsIgnoreCase(environment.getProperty("spring.thymeleaf.cache"))) {
+            return Optional.of(false);
+        }
+        return Optional.empty();
     }
 
     @Bean

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentServiceTest.java
@@ -1,0 +1,90 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaDocContentServiceTest {
+
+    @Test
+    void loadJavaDocInfos_shouldRereadTemplateWhenCacheIsDisabled() throws Exception {
+        Path template = new ClassPathResource("templates/cache/devtools-cache-sample.html").getFile().toPath();
+        String original = Files.readString(template, StandardCharsets.UTF_8);
+        JavaDocContentService service = buildService(false);
+
+        try {
+            Files.writeString(template, templateContent("Before update"), StandardCharsets.UTF_8);
+            List<JavaDocAnalyzer.JavaDocInfo> before = service.loadJavaDocInfos("cache/devtools-cache-sample");
+
+            Files.writeString(template, templateContent("After update"), StandardCharsets.UTF_8);
+            List<JavaDocAnalyzer.JavaDocInfo> after = service.loadJavaDocInfos("cache/devtools-cache-sample");
+
+            assertThat(before).singleElement()
+                .extracting(JavaDocAnalyzer.JavaDocInfo::getDescription)
+                .isEqualTo("Before update");
+            assertThat(after).singleElement()
+                .extracting(JavaDocAnalyzer.JavaDocInfo::getDescription)
+                .isEqualTo("After update");
+        } finally {
+            Files.writeString(template, original, StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void loadJavaDocInfos_shouldReuseTemplateWhenCacheIsEnabled() throws Exception {
+        Path template = new ClassPathResource("templates/cache/devtools-cache-sample.html").getFile().toPath();
+        String original = Files.readString(template, StandardCharsets.UTF_8);
+        JavaDocContentService service = buildService(true);
+
+        try {
+            Files.writeString(template, templateContent("Cached value"), StandardCharsets.UTF_8);
+            List<JavaDocAnalyzer.JavaDocInfo> before = service.loadJavaDocInfos("cache/devtools-cache-sample");
+
+            Files.writeString(template, templateContent("Updated value"), StandardCharsets.UTF_8);
+            List<JavaDocAnalyzer.JavaDocInfo> after = service.loadJavaDocInfos("cache/devtools-cache-sample");
+
+            assertThat(before).singleElement()
+                .extracting(JavaDocAnalyzer.JavaDocInfo::getDescription)
+                .isEqualTo("Cached value");
+            assertThat(after).singleElement()
+                .extracting(JavaDocAnalyzer.JavaDocInfo::getDescription)
+                .isEqualTo("Cached value");
+        } finally {
+            Files.writeString(template, original, StandardCharsets.UTF_8);
+        }
+    }
+
+    private JavaDocContentService buildService(boolean cacheEnabled) {
+        StorybookProperties properties = new StorybookProperties();
+        StorybookProperties.CacheConfig cache = new StorybookProperties.CacheConfig();
+        cache.setEnabled(cacheEnabled);
+        properties.setCache(cache);
+
+        return new JavaDocContentService(
+            new JavaDocAnalyzer(),
+            ResolvedStorybookConfig.from(properties),
+            new ResourcePathValidator()
+        );
+    }
+
+    private String templateContent(String description) {
+        return """
+            <!--
+            /**
+             * %s
+             * @example <div th:replace="~{cache/devtools-cache-sample :: sample()}"></div>
+             */
+            -->
+            <div th:fragment="sample()">Sample</div>
+            """.formatted(description);
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.mock.env.MockEnvironment;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 
@@ -80,6 +81,29 @@ class StorybookAutoConfigurationTest {
         assertEquals(Set.of("thymeleaflet/**"), resolver.getResolvablePatterns());
         assertEquals(Integer.valueOf(0), resolver.getOrder());
         assertFalse(resolver.getCheckExistence(), "Resolver should open the classpath resource directly");
+    }
+
+    @Test
+    void resolvedStorybookConfig_shouldDisableThymeleafletCacheWhenThymeleafCacheIsDisabledByDevelopmentConfig() {
+        StorybookAutoConfiguration configuration = new StorybookAutoConfiguration();
+        MockEnvironment environment = new MockEnvironment()
+            .withProperty("spring.thymeleaf.cache", "false");
+
+        ResolvedStorybookConfig resolved = configuration.resolvedStorybookConfig(new StorybookProperties(), environment);
+
+        assertFalse(resolved.getCache().isEnabled());
+    }
+
+    @Test
+    void resolvedStorybookConfig_shouldRespectExplicitThymeleafletCacheSetting() {
+        StorybookAutoConfiguration configuration = new StorybookAutoConfiguration();
+        MockEnvironment environment = new MockEnvironment()
+            .withProperty("spring.thymeleaf.cache", "false")
+            .withProperty("thymeleaflet.cache.enabled", "true");
+
+        ResolvedStorybookConfig resolved = configuration.resolvedStorybookConfig(new StorybookProperties(), environment);
+
+        assertTrue(resolved.getCache().isEnabled());
     }
 
     @Test

--- a/src/test/resources/templates/cache/devtools-cache-sample.html
+++ b/src/test/resources/templates/cache/devtools-cache-sample.html
@@ -1,0 +1,7 @@
+<!--
+/**
+ * Initial cache sample
+ * @example <div th:replace="~{cache/devtools-cache-sample :: sample()}"></div>
+ */
+-->
+<div th:fragment="sample()">Sample</div>


### PR DESCRIPTION
## Summary

Align Thymeleaflet internal cache behavior with development Thymeleaf cache settings. When `spring.thymeleaf.cache=false` and `thymeleaflet.cache.enabled` is not explicitly set, Thymeleaflet disables its own caches so template-only edits refresh JavaDoc data during development.

Closes #132

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=StorybookAutoConfigurationTest,JavaDocContentServiceTest test`
- `./mvnw -q -Dfrontend.skip=true test`
- `./mvnw -q -Dfrontend.skip=true -DskipTests install`
- `npm run test:e2e` (9 passed)
