### PR TITLE
Add explicit JavaDoc fragment tag matching

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,6 +131,7 @@ thymeleaflet:
 /**
  * 会員情報詳細表示（memberDetail）
  *
+ * @fragment memberDetail
  * @param variant {@code String} [optional=standard] 表示バリアント
  * @model memberProfile {@code List<Map<String, Object>>} [required] 会員情報モデル
  * @example <div th:replace="~{domain/member/organisms/member-profile :: memberDetail()}"></div>
@@ -138,6 +139,9 @@ thymeleaflet:
  */
 -->
 ```
+
+説明文にフラグメント名を含めない場合（日本語などのローカライズされた説明文）は、`@fragment <name>` で
+JavaDoc とフラグメントを明示的に対応付けられます。未指定の場合は従来どおり `@example` と説明文で照合します。
 
 ## フラグメントシグネチャ解析ポリシー
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Thymeleaflet parses JavaDoc-style comments embedded in HTML templates. Example:
 /**
  * Member detail (memberDetail)
  *
+ * @fragment memberDetail
  * @param variant {@code String} [optional=standard] Display variant
  * @model memberProfile {@code List<Map<String, Object>>} [required] Member model
  * @example <div th:replace="~{domain/member/organisms/member-profile :: memberDetail()}"></div>
@@ -143,6 +144,9 @@ Thymeleaflet parses JavaDoc-style comments embedded in HTML templates. Example:
  */
 -->
 ```
+
+Use `@fragment <name>` to bind JavaDoc explicitly to a fragment when the description does not include the fragment name,
+for example in localized documentation. If omitted, Thymeleaflet falls back to `@example` and description matching.
 
 ## Fragment Signature Parsing Policy
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
@@ -28,13 +28,18 @@ public class JavaDocAnalyzer {
     );
     
     private static final Pattern PARAM_PATTERN = Pattern.compile(
-        "@param\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@example|\\s*@background|\\s*\\*/|$)",
+        "@param\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
         Pattern.MULTILINE | Pattern.DOTALL
     );
 
     private static final Pattern MODEL_PATTERN = Pattern.compile(
-        "@model\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@example|\\s*@background|\\s*\\*/|$)",
+        "@model\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
         Pattern.MULTILINE | Pattern.DOTALL
+    );
+
+    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
+        "@fragment\\s+([A-Za-z_][\\w-]*)",
+        Pattern.MULTILINE
     );
     
     private static final Pattern EXAMPLE_PATTERN = Pattern.compile(
@@ -66,11 +71,12 @@ public class JavaDocAnalyzer {
             // 技術的データ抽出処理
             List<ParameterInfo> parameters = parseParameters(javadocContent);
             List<ModelInfo> models = parseModels(javadocContent);
+            Optional<String> fragmentName = parseFragmentName(javadocContent);
             List<ExampleInfo> examples = parseExamples(javadocContent);
             Optional<String> backgroundColor = parseBackgroundColor(javadocContent);
             String description = extractDescription(javadocContent);
             
-            JavaDocInfo docInfo = JavaDocInfo.of(description, parameters, models, examples, backgroundColor);
+            JavaDocInfo docInfo = JavaDocInfo.of(description, parameters, models, fragmentName, examples, backgroundColor);
             docInfoList.add(docInfo);
         }
         
@@ -168,6 +174,17 @@ public class JavaDocAnalyzer {
     }
     
     /**
+     * @fragmentタグから明示的なフラグメント名を解析
+     */
+    private Optional<String> parseFragmentName(String javadocContent) {
+        Matcher fragmentMatcher = FRAGMENT_PATTERN.matcher(javadocContent);
+        if (fragmentMatcher.find()) {
+            return Optional.of(fragmentMatcher.group(1));
+        }
+        return Optional.empty();
+    }
+
+    /**
      * @exampleタグから使用例を解析
      */
     private List<ExampleInfo> parseExamples(String javadocContent) {
@@ -251,6 +268,7 @@ public class JavaDocAnalyzer {
         private final String description;
         private final List<ParameterInfo> parameters;
         private final List<ModelInfo> models;
+        private final Optional<String> fragmentName;
         private final List<ExampleInfo> examples;
         private final Optional<String> backgroundColor;
         
@@ -264,12 +282,14 @@ public class JavaDocAnalyzer {
             String description,
             List<ParameterInfo> parameters,
             List<ModelInfo> models,
+            Optional<String> fragmentName,
             List<ExampleInfo> examples,
             Optional<String> backgroundColor
         ) {
             this.description = description;
             this.parameters = Collections.unmodifiableList(new ArrayList<>(parameters));
             this.models = Collections.unmodifiableList(new ArrayList<>(models));
+            this.fragmentName = Objects.requireNonNull(fragmentName, "fragmentName cannot be null");
             this.examples = Collections.unmodifiableList(new ArrayList<>(examples));
             this.backgroundColor = Objects.requireNonNull(backgroundColor, "backgroundColor cannot be null");
         }
@@ -284,7 +304,18 @@ public class JavaDocAnalyzer {
             List<ExampleInfo> examples,
             Optional<String> backgroundColor
         ) {
-            return new JavaDocInfo(description, parameters, models, examples, backgroundColor);
+            return new JavaDocInfo(description, parameters, models, Optional.empty(), examples, backgroundColor);
+        }
+
+        public static JavaDocInfo of(
+            String description,
+            List<ParameterInfo> parameters,
+            List<ModelInfo> models,
+            Optional<String> fragmentName,
+            List<ExampleInfo> examples,
+            Optional<String> backgroundColor
+        ) {
+            return new JavaDocInfo(description, parameters, models, fragmentName, examples, backgroundColor);
         }
 
         public static JavaDocInfo of(
@@ -294,7 +325,7 @@ public class JavaDocAnalyzer {
             List<ExampleInfo> examples,
             String backgroundColor
         ) {
-            return new JavaDocInfo(description, parameters, models, examples, Optional.ofNullable(backgroundColor));
+            return new JavaDocInfo(description, parameters, models, Optional.empty(), examples, Optional.ofNullable(backgroundColor));
         }
 
         /**
@@ -306,7 +337,7 @@ public class JavaDocAnalyzer {
             List<ExampleInfo> examples,
             Optional<String> backgroundColor
         ) {
-            return new JavaDocInfo(description, parameters, Collections.emptyList(), examples, backgroundColor);
+            return new JavaDocInfo(description, parameters, Collections.emptyList(), Optional.empty(), examples, backgroundColor);
         }
 
         public static JavaDocInfo of(
@@ -315,28 +346,30 @@ public class JavaDocAnalyzer {
             List<ExampleInfo> examples,
             String backgroundColor
         ) {
-            return new JavaDocInfo(description, parameters, Collections.emptyList(), examples, Optional.ofNullable(backgroundColor));
+            return new JavaDocInfo(description, parameters, Collections.emptyList(), Optional.empty(), examples, Optional.ofNullable(backgroundColor));
         }
         
         /**
          * JavaDocInfo作成 - ファクトリメソッド（基本版）
          */
         public static JavaDocInfo of(String description) {
-            return new JavaDocInfo(description, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Optional.empty());
+            return new JavaDocInfo(description, Collections.emptyList(), Collections.emptyList(), Optional.empty(), Collections.emptyList(), Optional.empty());
         }
         
         // Getters
         public String getDescription() { return description; }
         public List<ParameterInfo> getParameters() { return parameters; }
         public List<ModelInfo> getModels() { return models; }
+        public String getFragmentName() { return fragmentName.orElse(""); }
+        public Optional<String> getFragmentNameOptional() { return fragmentName; }
         public List<ExampleInfo> getExamples() { return examples; }
         public String getBackgroundColor() { return backgroundColor.orElse(""); }
         public Optional<String> getBackgroundColorOptional() { return backgroundColor; }
         
         @Override
         public String toString() {
-            return String.format("JavaDocInfo{description='%s', parameters=%d, models=%d, examples=%d, background='%s'}",
-                               description, parameters.size(), models.size(), examples.size(), backgroundColor.orElse(""));
+            return String.format("JavaDocInfo{description='%s', parameters=%d, models=%d, fragment='%s', examples=%d, background='%s'}",
+                               description, parameters.size(), models.size(), fragmentName.orElse(""), examples.size(), backgroundColor.orElse(""));
         }
     }
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupService.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -34,17 +35,29 @@ public class JavaDocLookupService implements JavaDocLookupPort {
 
         try {
             return javadocInfos.stream()
-                .filter(doc -> {
-                    boolean matchesDescription = doc.getDescription().toLowerCase().contains(fragmentName.toLowerCase());
-                    boolean matchesExample = doc.getExamples().stream()
-                        .anyMatch(ex -> ex.getFragmentName().equals(fragmentName));
-                    return matchesDescription || matchesExample;
-                })
+                .filter(doc -> matchesFragmentTag(doc, fragmentName)
+                    || matchesExample(doc, fragmentName)
+                    || matchesDescription(doc, fragmentName))
                 .findFirst();
         } catch (Exception e) {
             logger.warn("Failed to read JavaDoc info for {}::{}: {}", templatePath, fragmentName, e.getMessage());
             return Optional.empty();
         }
+    }
+
+    private boolean matchesFragmentTag(JavaDocAnalyzer.JavaDocInfo doc, String fragmentName) {
+        return doc.getFragmentNameOptional()
+            .filter(fragmentName::equals)
+            .isPresent();
+    }
+
+    private boolean matchesExample(JavaDocAnalyzer.JavaDocInfo doc, String fragmentName) {
+        return doc.getExamples().stream()
+            .anyMatch(ex -> ex.getFragmentName().equals(fragmentName));
+    }
+
+    private boolean matchesDescription(JavaDocAnalyzer.JavaDocInfo doc, String fragmentName) {
+        return doc.getDescription().toLowerCase(Locale.ROOT).contains(fragmentName.toLowerCase(Locale.ROOT));
     }
 
     @Override

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
@@ -272,6 +272,35 @@ class JavaDocAnalyzerTest {
     }
 
     @Test
+    @DisplayName("@fragmentタグから明示的なフラグメント名を解析できる")
+    void shouldParseFragmentTag() {
+        // Given
+        String htmlContent = """
+            <!--
+            /**
+             * 会員情報パネル（HTMX パーシャル）
+             *
+             * @fragment myPanel
+             * @model field1 {@code String} [required] フィールド1
+             */
+            -->
+            <section th:fragment="myPanel">Panel</section>
+            """;
+
+        // When
+        List<JavaDocAnalyzer.JavaDocInfo> result = analyzer.analyzeJavaDocFromHtml(htmlContent);
+
+        // Then
+        assertThat(result).hasSize(1);
+        JavaDocAnalyzer.JavaDocInfo docInfo = result.get(0);
+        assertThat(docInfo.getDescription()).isEqualTo("会員情報パネル（HTMX パーシャル）");
+        assertThat(docInfo.getFragmentNameOptional()).contains("myPanel");
+        assertThat(docInfo.getModels()).singleElement()
+            .extracting(JavaDocAnalyzer.ModelInfo::getDescription)
+            .isEqualTo("フィールド1");
+    }
+
+    @Test
     @DisplayName("@exampleタグでth:blockと引数なしフラグメントを解析できる")
     void shouldParseThBlockAndNoArgumentExamples() {
         // Given

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupServiceTest.java
@@ -1,0 +1,71 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocAnalyzer;
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocContentService;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaDocLookupServiceTest {
+
+    @Test
+    void findJavaDocInfo_shouldMatchExplicitFragmentTagForLocalizedDescription() {
+        JavaDocAnalyzer.JavaDocInfo docInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "会員情報パネル（HTMX パーシャル）",
+            Collections.emptyList(),
+            List.of(JavaDocAnalyzer.ModelInfo.required("field1", "String", "フィールド1")),
+            Optional.of("myPanel"),
+            Collections.emptyList(),
+            Optional.empty()
+        );
+        JavaDocContentService javaDocContentService = new StubJavaDocContentService(List.of(docInfo));
+        JavaDocLookupService service = new JavaDocLookupService(javaDocContentService);
+
+        Optional<JavaDocAnalyzer.JavaDocInfo> result = service.findJavaDocInfo("partials/my-panel", "myPanel");
+
+        assertThat(result).containsSame(docInfo);
+    }
+
+    @Test
+    void findJavaDocInfo_shouldStillMatchExampleWhenFragmentTagIsAbsent() {
+        JavaDocAnalyzer.JavaDocInfo docInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "Localized panel description",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            List.of(JavaDocAnalyzer.ExampleInfo.of("partials/my-panel", "myPanel")),
+            Optional.empty()
+        );
+        JavaDocContentService javaDocContentService = new StubJavaDocContentService(List.of(docInfo));
+        JavaDocLookupService service = new JavaDocLookupService(javaDocContentService);
+
+        Optional<JavaDocAnalyzer.JavaDocInfo> result = service.findJavaDocInfo("partials/my-panel", "myPanel");
+
+        assertThat(result).containsSame(docInfo);
+    }
+
+    private static final class StubJavaDocContentService extends JavaDocContentService {
+
+        private final List<JavaDocAnalyzer.JavaDocInfo> docs;
+
+        private StubJavaDocContentService(List<JavaDocAnalyzer.JavaDocInfo> docs) {
+            super(
+                new JavaDocAnalyzer(),
+                ResolvedStorybookConfig.from(new StorybookProperties()),
+                new ResourcePathValidator()
+            );
+            this.docs = docs;
+        }
+
+        @Override
+        public List<JavaDocAnalyzer.JavaDocInfo> loadJavaDocInfos(String templatePath) {
+            return docs;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add explicit `@fragment <fragmentName>` support for JavaDoc comments and prefer it before `@example` and description-based matching. This lets localized JavaDoc descriptions, including Japanese text that does not contain the English fragment name, still bind to the correct fragment without requiring an example tag.

Closes #131

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=JavaDocAnalyzerTest,JavaDocLookupServiceTest test`
- `./mvnw -q -Dfrontend.skip=true test`
- `./mvnw -q -Dfrontend.skip=true -DskipTests install`
- `npm run test:e2e` (9 passed)
