### PR TITLE
Prepare release 0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.18] - 2026-05-01
+
+- Added
+  - Added explicit `@fragment <name>` JavaDoc binding so localized descriptions can be matched to fragments without requiring the fragment name to appear in the text. (#131)
+- Changed
+  - When `spring.thymeleaf.cache=false` and `thymeleaflet.cache.enabled` is not explicitly set, Thymeleaflet now disables its internal JavaDoc/template caches during development so template-only edits are reflected on reload. (#132)
+- Fixed
+  - Expanded `@example` parsing to support `<th:block th:replace="...">` and no-argument fragment references without parentheses. (#130)
+- Docs
+  - Documented the new `@fragment` JavaDoc tag and development cache behavior in both English and Japanese README files.
+- Test
+  - Added regression coverage for `@fragment` lookup, localized JavaDoc descriptions, `th:block` examples, no-argument examples, and disabled JavaDoc template caching.
+- Build
+  - Updated Maven project and sample app versions to `0.2.18`.
+
+### Issues
+
+- #130 `@example` が `<th:block>` や引数なしフラグメントで解析されない
+- #131 日本語（非ASCII）の JavaDoc 説明文では matchesDescription が機能しない
+- #132 Spring Boot DevTools 環境でテンプレート変更後に JavaDoc キャッシュが更新されない
+
 ## [0.2.17] - 2026-05-01
 
 - Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.17</version>
+  <version>0.2.18</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.17")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.18")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.17</version>
+  <version>0.2.18</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.17")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.18")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.17</version>
+    <version>0.2.18</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.17</version>
+    <version>0.2.18</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.17</version>
+            <version>0.2.18</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

Prepare release `0.2.18`.

This release includes:
- `@example` parsing support for `<th:block>` and no-argument fragments (#130)
- explicit `@fragment <name>` JavaDoc binding for localized descriptions (#131)
- development cache behavior aligned with `spring.thymeleaf.cache=false` (#132)

Closes: N/A

## Verification

- `./mvnw test -q`
- `npm run test:e2e:local` (9 passed)
- Confirmed no sample app remains listening on port `6006`
