### PR TITLE
Centralize Thymeleaflet cache management

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -49,6 +49,10 @@ JavaScript を使いたい場合は `resources.scripts` に登録してくださ
 | `thymeleaflet.cache.enabled` | boolean | `true` | フラグメント探索・JavaDoc解析・依存解析のメモリキャッシュ |
 | `thymeleaflet.cache.preload` | boolean | `false` | 起動時にキャッシュをウォームアップ |
 
+`spring.thymeleaf.cache=false` かつ `thymeleaflet.cache.enabled` が明示されていない場合、Thymeleaflet の内部
+キャッシュも無効になります。DevTools でのテンプレート再読込時に、フラグメント探索・JavaDoc 解析・型抽出・依存解析が
+古いキャッシュではなくソースリソースを読み直すためです。
+
 ## セキュリティ補助設定
 
 | プロパティ | 型 | デフォルト | 説明 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,10 @@ Each item supports `id`, `label`, and `width`.
 | `thymeleaflet.cache.enabled` | boolean | `true` | Enables in-memory caches for fragment discovery, JavaDoc parsing, and dependency analysis |
 | `thymeleaflet.cache.preload` | boolean | `false` | Preload caches at startup (useful for low-CPU demo environments) |
 
+When `spring.thymeleaf.cache=false` and `thymeleaflet.cache.enabled` is not set explicitly, Thymeleaflet disables its
+internal caches as well. This keeps DevTools-style template reloads predictable because fragment discovery, JavaDoc
+parsing, type extraction, and dependency analysis reread source resources instead of returning stale cache entries.
+
 ## Security Helper Configuration
 
 | Property | Type | Default | Description |

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -1,6 +1,7 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,23 +33,23 @@ public class FragmentDiscoveryService {
     
     private final PathMatchingResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
 
-    private volatile boolean cacheInitialized;
-    private volatile List<FragmentInfo> cachedFragments = List.of();
-
     private final FragmentDomainService fragmentDomainService;
 
     private final ResolvedStorybookConfig storybookConfig;
 
     private final FragmentSignatureParser fragmentSignatureParser;
+    private final ThymeleafletCacheManager cacheManager;
 
     public FragmentDiscoveryService(
         FragmentDomainService fragmentDomainService,
         ResolvedStorybookConfig storybookConfig,
-        FragmentSignatureParser fragmentSignatureParser
+        FragmentSignatureParser fragmentSignatureParser,
+        ThymeleafletCacheManager cacheManager
     ) {
         this.fragmentDomainService = fragmentDomainService;
         this.storybookConfig = storybookConfig;
         this.fragmentSignatureParser = fragmentSignatureParser;
+        this.cacheManager = cacheManager;
     }
     
     /**
@@ -56,8 +57,9 @@ public class FragmentDiscoveryService {
      */
     public List<FragmentInfo> discoverFragments() {
         logger.debug("[DEBUG_FRAGMENT_PARAMS] Starting fragment discovery process");
-        if (storybookConfig.getCache().isEnabled() && cacheInitialized) {
-            return cachedFragments;
+        Optional<List<FragmentInfo>> cached = cacheManager.get("fragment-discovery", "all");
+        if (cached.isPresent()) {
+            return cached.orElseThrow();
         }
         List<FragmentInfo> fragments = new ArrayList<>();
         
@@ -101,13 +103,9 @@ public class FragmentDiscoveryService {
             logger.debug("[DEBUG_FRAGMENT_PARAMS] Final fragment: {}", fragment.toString());
         }
         
-        if (storybookConfig.getCache().isEnabled()) {
-            cachedFragments = Collections.unmodifiableList(new ArrayList<>(fragments));
-            cacheInitialized = true;
-            return cachedFragments;
-        }
-
-        return fragments;
+        List<FragmentInfo> immutableFragments = Collections.unmodifiableList(new ArrayList<>(fragments));
+        cacheManager.put("fragment-discovery", "all", immutableFragments);
+        return immutableFragments;
     }
     
     /**

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentService.java
@@ -2,17 +2,16 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * JavaDoc解析用のテンプレート読み込みと解析を集約するサービス。
@@ -25,23 +24,22 @@ public class JavaDocContentService {
     private final JavaDocAnalyzer javaDocAnalyzer;
     private final ResolvedStorybookConfig storybookConfig;
     private final ResourcePathValidator resourcePathValidator;
-    private final Map<String, List<JavaDocAnalyzer.JavaDocInfo>> javaDocCache = new ConcurrentHashMap<>();
-    private final Map<String, String> templateCache = new ConcurrentHashMap<>();
+    private final ThymeleafletCacheManager cacheManager;
 
     public JavaDocContentService(JavaDocAnalyzer javaDocAnalyzer,
                                  ResolvedStorybookConfig storybookConfig,
-                                 ResourcePathValidator resourcePathValidator) {
+                                 ResourcePathValidator resourcePathValidator,
+                                 ThymeleafletCacheManager cacheManager) {
         this.javaDocAnalyzer = javaDocAnalyzer;
         this.storybookConfig = storybookConfig;
         this.resourcePathValidator = resourcePathValidator;
+        this.cacheManager = cacheManager;
     }
 
     public Optional<String> loadTemplateContent(String templatePath) {
-        if (storybookConfig.getCache().isEnabled()) {
-            Optional<String> cached = Optional.ofNullable(templateCache.get(templatePath));
-            if (cached.isPresent()) {
-                return cached;
-            }
+        Optional<String> cached = cacheManager.get("template-content", templatePath);
+        if (cached.isPresent()) {
+            return cached;
         }
         try {
             Resource resource = resourcePathValidator.findTemplate(
@@ -55,9 +53,7 @@ public class JavaDocContentService {
             }
 
             String content = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            if (storybookConfig.getCache().isEnabled()) {
-                templateCache.put(templatePath, content);
-            }
+            cacheManager.put("template-content", templatePath, content);
             return Optional.of(content);
         } catch (Exception e) {
             logger.warn("Failed to read template content for {}: {}", templatePath, e.getMessage());
@@ -66,11 +62,9 @@ public class JavaDocContentService {
     }
 
     public List<JavaDocAnalyzer.JavaDocInfo> loadJavaDocInfos(String templatePath) {
-        if (storybookConfig.getCache().isEnabled()) {
-            Optional<List<JavaDocAnalyzer.JavaDocInfo>> cached = Optional.ofNullable(javaDocCache.get(templatePath));
-            if (cached.isPresent()) {
-                return cached.orElseThrow();
-            }
+        Optional<List<JavaDocAnalyzer.JavaDocInfo>> cached = cacheManager.get("javadocs", templatePath);
+        if (cached.isPresent()) {
+            return cached.orElseThrow();
         }
         Optional<String> htmlContent = loadTemplateContent(templatePath);
         if (htmlContent.isEmpty() || htmlContent.get().isBlank()) {
@@ -79,9 +73,7 @@ public class JavaDocContentService {
 
         try {
             List<JavaDocAnalyzer.JavaDocInfo> docs = javaDocAnalyzer.analyzeJavaDocFromHtml(htmlContent.get());
-            if (storybookConfig.getCache().isEnabled()) {
-                javaDocCache.put(templatePath, docs);
-            }
+            cacheManager.put("javadocs", templatePath, docs);
             return docs;
         } catch (Exception e) {
             logger.warn("Failed to analyze JavaDoc for {}: {}", templatePath, e.getMessage());

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/service/DocumentationAnalysisAdapter.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/service/DocumentationAnalysisAdapter.java
@@ -4,16 +4,14 @@ import io.github.wamukat.thymeleaflet.application.port.outbound.DocumentationAna
 import io.github.wamukat.thymeleaflet.domain.model.TypeInfo;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocContentService;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.TypeInformationExtractor;
-import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * ドキュメント解析アダプタ
@@ -27,24 +25,21 @@ public class DocumentationAnalysisAdapter implements DocumentationAnalysisPort {
     
     private final TypeInformationExtractor typeInformationExtractor;
     private final JavaDocContentService javaDocContentService;
-    private final ResolvedStorybookConfig storybookConfig;
-    private final Map<String, List<TypeInfo>> typeInfoCache = new ConcurrentHashMap<>();
+    private final ThymeleafletCacheManager cacheManager;
     
     public DocumentationAnalysisAdapter(TypeInformationExtractor typeInformationExtractor,
                                         JavaDocContentService javaDocContentService,
-                                        ResolvedStorybookConfig storybookConfig) {
+                                        ThymeleafletCacheManager cacheManager) {
         this.typeInformationExtractor = typeInformationExtractor;
         this.javaDocContentService = javaDocContentService;
-        this.storybookConfig = storybookConfig;
+        this.cacheManager = cacheManager;
     }
     
     @Override
     public List<TypeInfo> extractTypeInformation(String templatePath) {
-        if (storybookConfig.getCache().isEnabled()) {
-            Optional<List<TypeInfo>> cached = Optional.ofNullable(typeInfoCache.get(templatePath));
-            if (cached.isPresent()) {
-                return cached.orElseThrow();
-            }
+        Optional<List<TypeInfo>> cached = cacheManager.get("type-info", templatePath);
+        if (cached.isPresent()) {
+            return cached.orElseThrow();
         }
         try {
             var htmlContent = javaDocContentService.loadTemplateContent(templatePath);
@@ -52,9 +47,7 @@ public class DocumentationAnalysisAdapter implements DocumentationAnalysisPort {
                 return new ArrayList<>();
             }
             List<TypeInfo> result = typeInformationExtractor.extractTypeInformationFromHtml(htmlContent.get());
-            if (storybookConfig.getCache().isEnabled()) {
-                typeInfoCache.put(templatePath, result);
-            }
+            cacheManager.put("type-info", templatePath, result);
             return result;
             
         } catch (Exception e) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/cache/ThymeleafletCacheManager.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/cache/ThymeleafletCacheManager.java
@@ -1,0 +1,57 @@
+package io.github.wamukat.thymeleaflet.infrastructure.cache;
+
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Central cache gateway for Thymeleaflet runtime-derived data.
+ *
+ * <p>When {@code thymeleaflet.cache.enabled=false}, all reads miss and writes are ignored. The
+ * auto-configuration also disables this cache when {@code spring.thymeleaf.cache=false} unless
+ * {@code thymeleaflet.cache.enabled} is explicitly set, so DevTools-style template reloads reread
+ * source resources by default.
+ */
+@Component
+public class ThymeleafletCacheManager {
+
+    private final ResolvedStorybookConfig storybookConfig;
+    private final Map<String, Map<Object, Object>> caches = new ConcurrentHashMap<>();
+
+    public ThymeleafletCacheManager(ResolvedStorybookConfig storybookConfig) {
+        this.storybookConfig = storybookConfig;
+    }
+
+    public boolean isEnabled() {
+        return storybookConfig.getCache().isEnabled();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> Optional<V> get(String cacheName, Object key) {
+        if (!isEnabled()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable((V) cache(cacheName).get(key));
+    }
+
+    public void put(String cacheName, Object key, Object value) {
+        if (!isEnabled()) {
+            return;
+        }
+        cache(cacheName).put(key, value);
+    }
+
+    public void clear(String cacheName) {
+        caches.remove(cacheName);
+    }
+
+    public void clearAll() {
+        caches.clear();
+    }
+
+    private Map<Object, Object> cache(String cacheName) {
+        return caches.computeIfAbsent(cacheName, ignored -> new ConcurrentHashMap<>());
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentDependencyPort;
 import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
@@ -15,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,23 +38,23 @@ public class FragmentDependencyService implements FragmentDependencyPort {
 
     private final ResourcePathValidator resourcePathValidator;
 
-    private final Map<String, List<DependencyComponent>> dependencyCache = new ConcurrentHashMap<>();
+    private final ThymeleafletCacheManager cacheManager;
 
     public FragmentDependencyService(
         ResolvedStorybookConfig storybookConfig,
-        ResourcePathValidator resourcePathValidator
+        ResourcePathValidator resourcePathValidator,
+        ThymeleafletCacheManager cacheManager
     ) {
         this.storybookConfig = storybookConfig;
         this.resourcePathValidator = resourcePathValidator;
+        this.cacheManager = cacheManager;
     }
 
     public List<DependencyComponent> findDependencies(String templatePath, String fragmentName) {
-        if (storybookConfig.getCache().isEnabled()) {
-            String cacheKey = templatePath + "::" + fragmentName;
-            List<DependencyComponent> cached = dependencyCache.get(cacheKey);
-            if (cached != null) {
-                return cached;
-            }
+        String cacheKey = templatePath + "::" + fragmentName;
+        Optional<List<DependencyComponent>> cached = cacheManager.get("fragment-dependencies", cacheKey);
+        if (cached.isPresent()) {
+            return cached.orElseThrow();
         }
         try {
             Resource resource = resourcePathValidator.findTemplate(
@@ -83,10 +83,9 @@ public class FragmentDependencyService implements FragmentDependencyPort {
             }
 
             List<DependencyComponent> result = new ArrayList<>(dependencies.values());
-            if (storybookConfig.getCache().isEnabled()) {
-                dependencyCache.put(templatePath + "::" + fragmentName, List.copyOf(result));
-            }
-            return result;
+            List<DependencyComponent> immutableResult = List.copyOf(result);
+            cacheManager.put("fragment-dependencies", cacheKey, immutableResult);
+            return immutableResult;
         } catch (Exception e) {
             logger.warn("Failed to extract dependencies for {}::{}: {}", templatePath, fragmentName, e.getMessage());
             return List.of();

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocContentServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
@@ -69,10 +70,12 @@ class JavaDocContentServiceTest {
         cache.setEnabled(cacheEnabled);
         properties.setCache(cache);
 
+        ResolvedStorybookConfig resolved = ResolvedStorybookConfig.from(properties);
         return new JavaDocContentService(
             new JavaDocAnalyzer(),
-            ResolvedStorybookConfig.from(properties),
-            new ResourcePathValidator()
+            resolved,
+            new ResourcePathValidator(),
+            new ThymeleafletCacheManager(resolved)
         );
     }
 

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/cache/ThymeleafletCacheManagerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/cache/ThymeleafletCacheManagerTest.java
@@ -1,0 +1,66 @@
+package io.github.wamukat.thymeleaflet.infrastructure.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
+import org.junit.jupiter.api.Test;
+
+class ThymeleafletCacheManagerTest {
+
+    @Test
+    void getAndPut_shouldStoreValuesWhenCacheIsEnabled() {
+        ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config(true));
+
+        cacheManager.put("templates", "components/card", "content");
+
+        assertThat(cacheManager.<String>get("templates", "components/card"))
+            .contains("content");
+    }
+
+    @Test
+    void getAndPut_shouldBypassStorageWhenCacheIsDisabled() {
+        ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config(false));
+
+        cacheManager.put("templates", "components/card", "content");
+
+        assertThat(cacheManager.<String>get("templates", "components/card"))
+            .isEmpty();
+    }
+
+    @Test
+    void clear_shouldInvalidateOneCacheWithoutAffectingOthers() {
+        ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config(true));
+        cacheManager.put("templates", "components/card", "content");
+        cacheManager.put("types", "components/card", "type info");
+
+        cacheManager.clear("templates");
+
+        assertThat(cacheManager.<String>get("templates", "components/card"))
+            .isEmpty();
+        assertThat(cacheManager.<String>get("types", "components/card"))
+            .contains("type info");
+    }
+
+    @Test
+    void clearAll_shouldInvalidateEveryCache() {
+        ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config(true));
+        cacheManager.put("templates", "components/card", "content");
+        cacheManager.put("types", "components/card", "type info");
+
+        cacheManager.clearAll();
+
+        assertThat(cacheManager.<String>get("templates", "components/card"))
+            .isEmpty();
+        assertThat(cacheManager.<String>get("types", "components/card"))
+            .isEmpty();
+    }
+
+    private ResolvedStorybookConfig config(boolean cacheEnabled) {
+        StorybookProperties properties = new StorybookProperties();
+        StorybookProperties.CacheConfig cache = new StorybookProperties.CacheConfig();
+        cache.setEnabled(cacheEnabled);
+        properties.setCache(cache);
+        return ResolvedStorybookConfig.from(properties);
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/JavaDocLookupServiceTest.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocAnalyzer;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocContentService;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
@@ -55,12 +56,21 @@ class JavaDocLookupServiceTest {
         private final List<JavaDocAnalyzer.JavaDocInfo> docs;
 
         private StubJavaDocContentService(List<JavaDocAnalyzer.JavaDocInfo> docs) {
+            this(docs, config());
+        }
+
+        private StubJavaDocContentService(List<JavaDocAnalyzer.JavaDocInfo> docs, ResolvedStorybookConfig config) {
             super(
                 new JavaDocAnalyzer(),
-                ResolvedStorybookConfig.from(new StorybookProperties()),
-                new ResourcePathValidator()
+                config,
+                new ResourcePathValidator(),
+                new ThymeleafletCacheManager(config)
             );
             this.docs = docs;
+        }
+
+        private static ResolvedStorybookConfig config() {
+            return ResolvedStorybookConfig.from(new StorybookProperties());
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Add `ThymeleafletCacheManager` as the central cache gateway for runtime-derived Thymeleaflet data.
- Route template content, JavaDoc, type info, fragment discovery, and dependency caches through the shared manager while preserving `cache.enabled` behavior.
- Document DevTools cache behavior in configuration docs.
- Add cache manager regression tests for enabled/disabled storage and invalidation.

## Verification
- ./mvnw -q -Dfrontend.skip=true -Dtest=ThymeleafletCacheManagerTest,JavaDocContentServiceTest,JavaDocLookupServiceTest test
- ./mvnw test -q
- npm run test:e2e:local
- git diff --check

Closes: N/A (Kanbalone #456)
