### PR TITLE
Separate template scanning and fragment parsing

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParser.java
@@ -1,0 +1,37 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FragmentDefinitionParser {
+
+    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
+        "th:fragment\\s*=\\s*[\"']([^\"']+)[\"']"
+    );
+
+    public List<FragmentDefinition> parseTemplate(String templatePath, String content) {
+        Objects.requireNonNull(templatePath, "templatePath cannot be null");
+        Objects.requireNonNull(content, "content cannot be null");
+        List<FragmentDefinition> definitions = new ArrayList<>();
+        Matcher matcher = FRAGMENT_PATTERN.matcher(content);
+
+        while (matcher.find()) {
+            definitions.add(new FragmentDefinition(templatePath, matcher.group(1)));
+        }
+
+        return List.copyOf(definitions);
+    }
+
+    public record FragmentDefinition(String templatePath, String definition) {
+        public FragmentDefinition {
+            templatePath = templatePath.trim();
+            definition = definition.trim();
+        }
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -2,22 +2,15 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
-import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Thymeleafフラグメントを自動発見・解析するサービス
@@ -27,27 +20,22 @@ public class FragmentDiscoveryService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentDiscoveryService.class);
     
-    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
-        "th:fragment\\s*=\\s*[\"']([^\"']+)[\"']"
-    );
-    
-    private final PathMatchingResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
-
+    private final TemplateScanner templateScanner;
+    private final FragmentDefinitionParser fragmentDefinitionParser;
     private final FragmentDomainService fragmentDomainService;
-
-    private final ResolvedStorybookConfig storybookConfig;
-
     private final FragmentSignatureParser fragmentSignatureParser;
     private final ThymeleafletCacheManager cacheManager;
 
     public FragmentDiscoveryService(
+        TemplateScanner templateScanner,
+        FragmentDefinitionParser fragmentDefinitionParser,
         FragmentDomainService fragmentDomainService,
-        ResolvedStorybookConfig storybookConfig,
         FragmentSignatureParser fragmentSignatureParser,
         ThymeleafletCacheManager cacheManager
     ) {
+        this.templateScanner = templateScanner;
+        this.fragmentDefinitionParser = fragmentDefinitionParser;
         this.fragmentDomainService = fragmentDomainService;
-        this.storybookConfig = storybookConfig;
         this.fragmentSignatureParser = fragmentSignatureParser;
         this.cacheManager = cacheManager;
     }
@@ -64,34 +52,18 @@ public class FragmentDiscoveryService {
         List<FragmentInfo> fragments = new ArrayList<>();
         
         try {
-            // 複数のテンプレートパスから検索
-            List<String> templatePaths = storybookConfig.getResources().getTemplatePaths();
-            logger.debug("[DEBUG_FRAGMENT_PARAMS] Searching in template paths: {}", templatePaths);
-            
-            for (String templatePath : templatePaths) {
-                String searchPattern = "classpath:" + templatePath + "**/*.html";
-                Resource[] resources = resourceResolver.getResources(searchPattern);
-                logger.debug("[DEBUG_FRAGMENT_PARAMS] Found {} template resources in path: {}", resources.length, templatePath);
-                
-                for (Resource resource : resources) {
-                    String relativeTemplatePath = extractTemplatePath(resource.getURI().toString());
-                    String content;
-                    try (var inputStream = resource.getInputStream()) {
-                        content = new String(inputStream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
-                    }
-                    
-                    logger.debug("[DEBUG_FRAGMENT_PARAMS] Processing template: {} (URI: {})", relativeTemplatePath, resource.getURI());
-                    
-                    // Storybook自身のフラグメントは除外
-                    if (relativeTemplatePath.startsWith("thymeleaflet/")) {
-                        logger.debug("[DEBUG_FRAGMENT_PARAMS] Skipping thymeleaflet internal template: {}", relativeTemplatePath);
-                        continue;
-                    }
-                    
-                    List<FragmentInfo> templateFragments = parseFragmentsFromTemplate(relativeTemplatePath, content);
-                    logger.debug("[DEBUG_FRAGMENT_PARAMS] Found {} fragments in template: {}", templateFragments.size(), relativeTemplatePath);
-                    fragments.addAll(templateFragments);
+            for (TemplateScanner.TemplateResource template : templateScanner.scanTemplates()) {
+                logger.debug("[DEBUG_FRAGMENT_PARAMS] Processing template: {} (URI: {})", template.templatePath(), template.uri());
+
+                // Storybook自身のフラグメントは除外
+                if (template.templatePath().startsWith("thymeleaflet/")) {
+                    logger.debug("[DEBUG_FRAGMENT_PARAMS] Skipping thymeleaflet internal template: {}", template.templatePath());
+                    continue;
                 }
+
+                List<FragmentInfo> templateFragments = parseFragmentsFromTemplate(template);
+                logger.debug("[DEBUG_FRAGMENT_PARAMS] Found {} fragments in template: {}", templateFragments.size(), template.templatePath());
+                fragments.addAll(templateFragments);
             }
         } catch (IOException e) {
             logger.error("[DEBUG_FRAGMENT_PARAMS] Fragment discovery failed", e);
@@ -111,13 +83,13 @@ public class FragmentDiscoveryService {
     /**
      * テンプレートからフラグメント情報を解析
      */
-    private List<FragmentInfo> parseFragmentsFromTemplate(String templatePath, String content) {
+    private List<FragmentInfo> parseFragmentsFromTemplate(TemplateScanner.TemplateResource template) {
         List<FragmentInfo> fragments = new ArrayList<>();
-        Matcher matcher = FRAGMENT_PATTERN.matcher(content);
-        
-        while (matcher.find()) {
-            String fragmentDefinition = matcher.group(1);
-            analyzeFragment(templatePath, fragmentDefinition).ifPresent(fragments::add);
+        for (FragmentDefinitionParser.FragmentDefinition definition : fragmentDefinitionParser.parseTemplate(
+            template.templatePath(),
+            template.content()
+        )) {
+            analyzeFragment(definition.templatePath(), definition.definition()).ifPresent(fragments::add);
         }
         
         return fragments;
@@ -180,30 +152,6 @@ public class FragmentDiscoveryService {
             );
         };
     }
-    
-    
-    /**
-     * リソースURIからテンプレートパスを抽出
-     */
-    private String extractTemplatePath(String resourceUri) {
-        // 複数のテンプレートパスから最初に見つかるものを使用
-        for (String templatePath : storybookConfig.getResources().getTemplatePaths()) {
-            String pathWithoutSlash = templatePath.substring(1); // 先頭の / を除去
-            int index = resourceUri.indexOf(pathWithoutSlash);
-            if (index != -1) {
-                return resourceUri.substring(index + pathWithoutSlash.length()).replace(".html", "");
-            }
-        }
-        
-        // フォールバック: templates/ で検索
-        int index = resourceUri.indexOf("templates/");
-        if (index != -1) {
-            return resourceUri.substring(index + "templates/".length()).replace(".html", "");
-        }
-        
-        return resourceUri;
-    }
-    
     /**
      * フラグメント情報を保持するクラス
      */

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/TemplateScanner.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/TemplateScanner.java
@@ -1,0 +1,75 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateScanner {
+
+    private final ResolvedStorybookConfig storybookConfig;
+    private final ResourcePatternResolver resourceResolver;
+
+    @Autowired
+    public TemplateScanner(ResolvedStorybookConfig storybookConfig) {
+        this(storybookConfig, new PathMatchingResourcePatternResolver());
+    }
+
+    TemplateScanner(ResolvedStorybookConfig storybookConfig, ResourcePatternResolver resourceResolver) {
+        this.storybookConfig = Objects.requireNonNull(storybookConfig, "storybookConfig cannot be null");
+        this.resourceResolver = Objects.requireNonNull(resourceResolver, "resourceResolver cannot be null");
+    }
+
+    public List<TemplateResource> scanTemplates() throws IOException {
+        List<TemplateResource> templates = new ArrayList<>();
+        for (String templatePath : storybookConfig.getResources().getTemplatePaths()) {
+            String searchPattern = "classpath:" + templatePath + "**/*.html";
+            Resource[] resources = resourceResolver.getResources(searchPattern);
+
+            for (Resource resource : resources) {
+                String resourceUri = resource.getURI().toString();
+                String relativeTemplatePath = extractTemplatePath(resourceUri);
+                String content;
+                try (var inputStream = resource.getInputStream()) {
+                    content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                }
+                templates.add(new TemplateResource(relativeTemplatePath, content, resourceUri));
+            }
+        }
+        return List.copyOf(templates);
+    }
+
+    private String extractTemplatePath(String resourceUri) {
+        for (String templatePath : storybookConfig.getResources().getTemplatePaths()) {
+            String pathWithoutSlash = templatePath.substring(1);
+            int index = resourceUri.indexOf(pathWithoutSlash);
+            if (index != -1) {
+                return resourceUri.substring(index + pathWithoutSlash.length()).replace(".html", "");
+            }
+        }
+
+        int index = resourceUri.indexOf("templates/");
+        if (index != -1) {
+            return resourceUri.substring(index + "templates/".length()).replace(".html", "");
+        }
+
+        return resourceUri;
+    }
+
+    public record TemplateResource(String templatePath, String content, String uri) {
+        public TemplateResource {
+            templatePath = templatePath.trim();
+            content = Objects.requireNonNull(content, "content cannot be null");
+            uri = Objects.requireNonNull(uri, "uri cannot be null");
+        }
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParserTest.java
@@ -1,0 +1,42 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class FragmentDefinitionParserTest {
+
+    private final FragmentDefinitionParser parser = new FragmentDefinitionParser();
+
+    @Test
+    void parseTemplate_shouldExtractFragmentDefinitionsInDeclarationOrder() {
+        String content = """
+            <section th:fragment="card(title, body)">Card</section>
+            <footer th:fragment='footer'>Footer</footer>
+            """;
+
+        List<FragmentDefinitionParser.FragmentDefinition> definitions = parser.parseTemplate(
+            "components/card",
+            content
+        );
+
+        assertThat(definitions)
+            .extracting(FragmentDefinitionParser.FragmentDefinition::definition)
+            .containsExactly("card(title, body)", "footer");
+        assertThat(definitions)
+            .extracting(FragmentDefinitionParser.FragmentDefinition::templatePath)
+            .containsExactly("components/card", "components/card");
+    }
+
+    @Test
+    void parseTemplate_shouldReturnEmptyListWhenTemplateHasNoFragments() {
+        List<FragmentDefinitionParser.FragmentDefinition> definitions = parser.parseTemplate(
+            "pages/home",
+            "<main>No fragments</main>"
+        );
+
+        assertThat(definitions).isEmpty();
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/TemplateScannerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/TemplateScannerTest.java
@@ -1,0 +1,83 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+class TemplateScannerTest {
+
+    @Test
+    void scanTemplates_shouldReadConfiguredClasspathResourcesAndNormalizeTemplatePath() throws IOException {
+        TemplateScanner scanner = new TemplateScanner(
+            resolvedConfigWithTemplatePath("/templates/"),
+            new StubResourcePatternResolver(new UriBackedResource(
+                "<div th:fragment=\"sample\">Sample</div>",
+                "file:/workspace/target/test-classes/templates/components/sample.html"
+            ))
+        );
+
+        List<TemplateScanner.TemplateResource> templates = scanner.scanTemplates();
+
+        assertThat(templates).hasSize(1);
+        TemplateScanner.TemplateResource template = templates.getFirst();
+        assertThat(template.templatePath()).isEqualTo("components/sample");
+        assertThat(template.content()).contains("th:fragment=\"sample\"");
+        assertThat(template.uri()).contains("templates/components/sample.html");
+    }
+
+    private static ResolvedStorybookConfig resolvedConfigWithTemplatePath(String templatePath) {
+        StorybookProperties properties = new StorybookProperties();
+        StorybookProperties.ResourceConfig resources = new StorybookProperties.ResourceConfig();
+        resources.setTemplatePaths(List.of(templatePath));
+        properties.setResources(resources);
+        return ResolvedStorybookConfig.from(properties);
+    }
+
+    private static final class StubResourcePatternResolver implements ResourcePatternResolver {
+        private final Resource resource;
+
+        private StubResourcePatternResolver(Resource resource) {
+            this.resource = resource;
+        }
+
+        @Override
+        public Resource[] getResources(String locationPattern) {
+            assertThat(locationPattern).isEqualTo("classpath:/templates/**/*.html");
+            return new Resource[] {resource};
+        }
+
+        @Override
+        public Resource getResource(String location) {
+            return resource;
+        }
+
+        @Override
+        public @Nullable ClassLoader getClassLoader() {
+            return TemplateScannerTest.class.getClassLoader();
+        }
+    }
+
+    private static final class UriBackedResource extends ByteArrayResource {
+        private final String uri;
+
+        private UriBackedResource(String content, String uri) {
+            super(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            this.uri = uri;
+        }
+
+        @Override
+        public URI getURI() {
+            return URI.create(uri);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Refactors fragment discovery responsibilities for Kanbalone#458:

- Adds `TemplateScanner` for configured classpath template enumeration, path normalization, and UTF-8 content loading.
- Adds `FragmentDefinitionParser` for `th:fragment` extraction from template content.
- Keeps `FragmentDiscoveryService` as orchestration over scanner, definition parser, signature parser, domain type classification, and cache.
- Adds focused parser/scanner unit coverage while preserving existing fragment discovery behavior.

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=FragmentDefinitionParserTest test` failed initially before `FragmentDefinitionParser` existed
- `./mvnw -q -Dfrontend.skip=true -Dtest=FragmentDefinitionParserTest,TemplateScannerTest,FragmentSignatureParserTest test`
- `./mvnw test -q`
- `npm run test:e2e:local` (9/9)
- `git diff --check`

Refs Kanbalone#458
