### PR TITLE
Harden Thymeleaflet production exposure controls

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -8,6 +8,7 @@
 
 | プロパティ | 型 | デフォルト | 説明 |
 |---|---|---|---|
+| `thymeleaflet.enabled` | boolean | `true` | Thymeleaflet の自動設定を有効化します。本番 profile では `false` にして開発用 UI の公開を防いでください |
 | `thymeleaflet.base-path` | String | `/thymeleaflet` | UI のベースパス |
 | `thymeleaflet.debug` | boolean | `false` | フラグメント探索のデバッグログ |
 
@@ -57,7 +58,10 @@ JavaScript を使いたい場合は `resources.scripts` に登録してくださ
 
 | プロパティ | 型 | デフォルト | 説明 |
 |---|---|---|---|
-| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: Spring Security 利用時に `/thymeleaflet/**` 許可の最小ルールを自動登録 |
+| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: Spring Security 利用時に `/thymeleaflet/**` 許可の最小ルールを自動登録。開発時の quick start 用です |
+
+`prod` または `production` profile が有効な状態で Thymeleaflet UI も有効な場合、起動時に WARN を出します。
+さらに `thymeleaflet.security.auto-permit=true` の場合は、UI パスを許可する高リスク設定として追加の WARN を出します。
 
 ### CSP 補足（意図的に緩め）
 
@@ -89,7 +93,13 @@ http.authorizeHttpRequests(auth -> auth
 ## 環境ごとの有効/無効
 
 Thymeleaflet は開発中の補助ツールとして利用する想定です。本番環境では
-自動設定を除外するか、本番ビルドから依存関係を外してください。
+`thymeleaflet.enabled=false` を設定するか、自動設定を除外するか、本番ビルドから依存関係を外してください。
+
+```yaml
+# application-prod.yml
+thymeleaflet:
+  enabled: false
+```
 
 ```yaml
 # application-prod.yml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ This page covers *only* configuration. Usage details are in
 
 | Property | Type | Default | Description |
 |---|---|---|---|
+| `thymeleaflet.enabled` | boolean | `true` | Enables the Thymeleaflet auto-configuration. Set `false` in production profiles to prevent exposing the development UI |
 | `thymeleaflet.base-path` | String | `/thymeleaflet` | Base URL for the UI |
 | `thymeleaflet.debug` | boolean | `false` | Enables debug logging for fragment discovery |
 
@@ -57,7 +58,12 @@ parsing, type extraction, and dependency analysis reread source resources instea
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: register minimal permit rule for `/thymeleaflet/**` when Spring Security is present |
+| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: register minimal permit rule for `/thymeleaflet/**` when Spring Security is present. Use only for development quick starts |
+
+When a `prod` or `production` profile is active, Thymeleaflet logs a warning if
+the UI is still enabled. It logs an additional warning when
+`thymeleaflet.security.auto-permit=true` is also active because that setting
+permits the UI path.
 
 ### CSP note (permissive by design)
 
@@ -90,7 +96,14 @@ http.authorizeHttpRequests(auth -> auth
 ## Enable/Disable by Environment
 
 Thymeleaflet is intended for development use. In production, disable it by
-excluding the auto-configuration (or remove the dependency from prod builds).
+setting `thymeleaflet.enabled=false`, excluding the auto-configuration, or
+removing the dependency from prod builds.
+
+```yaml
+# application-prod.yml
+thymeleaflet:
+  enabled: false
+```
 
 ```yaml
 # application-prod.yml

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -91,12 +91,22 @@ thymeleaflet:
   base-path: /thymeleaflet
 
 # application-prod.yml
+thymeleaflet:
+  enabled: false
+```
+
+auto-configuration を除外する方法も使えます:
+
+```yaml
+# application-prod.yml
 spring:
   autoconfigure:
     exclude: io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookAutoConfiguration
 ```
 
 本番ビルドから依存関係を外す運用でも問題ありません。
+`prod` または `production` profile で Thymeleaflet が有効な場合、起動時に WARN を出します。
+`thymeleaflet.security.auto-permit=true` の場合は UI パスを許可するため、追加の WARN を出します。
 
 Spring Security を使う場合は、次のいずれかを選択してください。
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,12 +91,23 @@ thymeleaflet:
   base-path: /thymeleaflet
 
 # application-prod.yml
+thymeleaflet:
+  enabled: false
+```
+
+You can also exclude the auto-configuration:
+
+```yaml
+# application-prod.yml
 spring:
   autoconfigure:
     exclude: io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookAutoConfiguration
 ```
 
-Alternatively, remove the dependency from production builds.
+Alternatively, remove the dependency from production builds. If Thymeleaflet is
+active under a `prod` or `production` profile, startup logs a warning.
+`thymeleaflet.security.auto-permit=true` logs an additional warning because it
+permits the UI path.
 
 If your app uses Spring Security, either:
 

--- a/docs/security.ja.md
+++ b/docs/security.ja.md
@@ -17,6 +17,8 @@ thymeleaflet:
 ```
 
 この設定で `/thymeleaflet/**` のみを許可する最小チェーンを登録します。
+ローカル開発または信頼できる内部環境向けの quick start として扱ってください。
+`prod` または `production` profile で `auto-permit=true` が有効な場合、起動時に WARN を出します。
 
 ### Option B: 利用側で明示設定
 
@@ -40,6 +42,12 @@ http.authorizeHttpRequests(auth -> auth
 - 企業内・限定 IP での運用を想定
 
 本番では自動設定を除外する方法がシンプルです:
+
+```yaml
+# application-prod.yml
+thymeleaflet:
+  enabled: false
+```
 
 ```yaml
 # application-prod.yml

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,6 +17,9 @@ thymeleaflet:
 ```
 
 This registers a minimal chain for `/thymeleaflet/**` only.
+Use this only for local development or trusted internal environments. If a
+`prod` or `production` profile is active, Thymeleaflet logs a warning when
+`auto-permit=true` is enabled.
 
 ### Option B: App-side explicit rule
 
@@ -39,6 +42,12 @@ http.authorizeHttpRequests(auth -> auth
 - Restrict `/thymeleaflet/**` in production as needed.
 - Use reverse proxy or IP restrictions for internal environments.
 - Disable Thymeleaflet in production when not needed.
+
+```yaml
+# application-prod.yml
+thymeleaflet:
+  enabled: false
+```
 
 ```yaml
 # application-prod.yml

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnostics.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnostics.java
@@ -1,0 +1,61 @@
+package io.github.wamukat.thymeleaflet.infrastructure.configuration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductionExposureDiagnostics implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProductionExposureDiagnostics.class);
+
+    private final Environment environment;
+    private final ResolvedStorybookConfig storybookConfig;
+
+    public ProductionExposureDiagnostics(Environment environment, ResolvedStorybookConfig storybookConfig) {
+        this.environment = environment;
+        this.storybookConfig = storybookConfig;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        for (String warning : warningMessages(environment, storybookConfig)) {
+            logger.warn(warning);
+        }
+    }
+
+    static List<String> warningMessages(Environment environment, ResolvedStorybookConfig storybookConfig) {
+        if (!hasProductionProfile(environment)) {
+            return List.of();
+        }
+
+        List<String> warnings = new ArrayList<>();
+        warnings.add(
+            "Thymeleaflet is active under a production profile. This tool is intended for development; "
+                + "set thymeleaflet.enabled=false, exclude StorybookAutoConfiguration, or remove the dependency "
+                + "from production builds."
+        );
+        if (storybookConfig.getSecurity().isAutoPermit()) {
+            warnings.add(
+                "thymeleaflet.security.auto-permit=true is active under a production profile and permits "
+                    + storybookConfig.getBasePath() + "/**. Prefer app-owned authentication rules or disable "
+                    + "Thymeleaflet in production."
+            );
+        }
+        return List.copyOf(warnings);
+    }
+
+    private static boolean hasProductionProfile(Environment environment) {
+        return Arrays.stream(environment.getActiveProfiles())
+            .map(String::trim)
+            .map(String::toLowerCase)
+            .anyMatch(profile -> profile.equals("prod") || profile.equals("production"));
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -16,6 +16,7 @@ import io.github.wamukat.thymeleaflet.domain.service.TemplateModelExpressionAnal
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.ThymeleafletAwareThymeleafView;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +54,7 @@ import org.thymeleaf.templateresolver.ITemplateResolver;
     "org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration"
 })
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnProperty(name = "thymeleaflet.enabled", havingValue = "true", matchIfMissing = true)
 @ComponentScan(basePackages = "io.github.wamukat.thymeleaflet")
 @EnableConfigurationProperties(StorybookProperties.class)
 public class StorybookAutoConfiguration {

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -10,7 +10,7 @@
     {
       "name": "thymeleaflet.enabled",
       "type": "java.lang.Boolean",
-      "description": "Enable or disable Thymeleaflet feature",
+      "description": "Enable or disable Thymeleaflet. Set false in production profiles to prevent exposing the development UI.",
       "defaultValue": true
     },
     {
@@ -45,7 +45,7 @@
     {
       "name": "thymeleaflet.security.auto-permit",
       "type": "java.lang.Boolean",
-      "description": "When true, registers a minimal SecurityFilterChain to permit /thymeleaflet/**",
+      "description": "When true, registers a minimal SecurityFilterChain to permit /thymeleaflet/**. Intended for development quick starts; avoid in production.",
       "defaultValue": false
     }
   ]

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnosticsTest.java
@@ -1,0 +1,56 @@
+package io.github.wamukat.thymeleaflet.infrastructure.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class ProductionExposureDiagnosticsTest {
+
+    @Test
+    void warningMessages_shouldWarnWhenThymeleafletIsActiveUnderProductionProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+
+        List<String> warnings = ProductionExposureDiagnostics.warningMessages(
+            environment,
+            ResolvedStorybookConfig.from(new StorybookProperties())
+        );
+
+        assertThat(warnings)
+            .anyMatch(message -> message.contains("production profile"));
+    }
+
+    @Test
+    void warningMessages_shouldWarnWhenAutoPermitIsActiveUnderProductionProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("production");
+        StorybookProperties properties = new StorybookProperties();
+        StorybookProperties.SecurityConfig security = new StorybookProperties.SecurityConfig();
+        security.setAutoPermit(true);
+        properties.setSecurity(security);
+
+        List<String> warnings = ProductionExposureDiagnostics.warningMessages(
+            environment,
+            ResolvedStorybookConfig.from(properties)
+        );
+
+        assertThat(warnings)
+            .anyMatch(message -> message.contains("thymeleaflet.security.auto-permit=true"));
+    }
+
+    @Test
+    void warningMessages_shouldStayQuietForDevelopmentProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("dev");
+
+        List<String> warnings = ProductionExposureDiagnostics.warningMessages(
+            environment,
+            ResolvedStorybookConfig.from(new StorybookProperties())
+        );
+
+        assertThat(warnings).isEmpty();
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.mock.env.MockEnvironment;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
@@ -49,6 +50,16 @@ class StorybookAutoConfigurationTest {
             ),
             "afterName should include Spring Boot 4 WebMvc auto-configuration"
         );
+    }
+
+    @Test
+    void autoConfiguration_shouldBeDisableableWithThymeleafletEnabledFalse() {
+        ConditionalOnProperty annotation = StorybookAutoConfiguration.class.getAnnotation(ConditionalOnProperty.class);
+
+        assertNotNull(annotation, "StorybookAutoConfiguration should support thymeleaflet.enabled=false");
+        assertEquals("thymeleaflet.enabled", annotation.name()[0]);
+        assertEquals("true", annotation.havingValue());
+        assertTrue(annotation.matchIfMissing());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Hardens production exposure controls for Kanbalone#459:

- Makes `thymeleaflet.enabled=false` effective via auto-configuration condition.
- Adds production-profile diagnostics that warn when Thymeleaflet is active under `prod`/`production`, with an extra warning for `thymeleaflet.security.auto-permit=true`.
- Updates configuration metadata and English/Japanese docs for production disablement and auto-permit risk.

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=StorybookAutoConfigurationTest,ProductionExposureDiagnosticsTest test` failed initially before `ProductionExposureDiagnostics` existed
- `./mvnw -q -Dfrontend.skip=true -Dtest=StorybookAutoConfigurationTest,ProductionExposureDiagnosticsTest test`
- `./mvnw test -q`
- `npm run test:e2e:local` (9/9)
- `git diff --check`

Refs Kanbalone#459
