### PR TITLE
Expand Spring configuration metadata

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -172,16 +172,20 @@ public class StorybookAutoConfiguration {
         String cssPath = basePath + "/css/**";
         String jsPath = basePath + "/js/**";
         String imagePath = basePath + "/images/**";
+        int cachePeriod = resolvedStorybookConfig.getResources().getCacheDurationSeconds();
         return new WebMvcConfigurer() {
             @Override
             public void addResourceHandlers(ResourceHandlerRegistry registry) {
                 // 静的リソース専用パスを限定（コントローラーマッピングと競合を避ける）
                 registry.addResourceHandler(cssPath)
-                        .addResourceLocations("classpath:/META-INF/resources/static/css/");
+                        .addResourceLocations("classpath:/META-INF/resources/static/css/")
+                        .setCachePeriod(cachePeriod);
                 registry.addResourceHandler(jsPath)
-                        .addResourceLocations("classpath:/META-INF/resources/static/js/");
+                        .addResourceLocations("classpath:/META-INF/resources/static/js/")
+                        .setCachePeriod(cachePeriod);
                 registry.addResourceHandler(imagePath)
-                        .addResourceLocations("classpath:/META-INF/resources/static/images/");
+                        .addResourceLocations("classpath:/META-INF/resources/static/images/")
+                        .setCachePeriod(cachePeriod);
                         
                 // CSS専用ハンドラー（fallback）（キャッシュなし）
                 registry.addResourceHandler("/css/thymeleaflet.css")

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -26,6 +26,44 @@
       "defaultValue": false
     },
     {
+      "name": "thymeleaflet.resources.template-paths",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Classpath template roots scanned for application fragments. Keep this to trusted application template locations.",
+      "defaultValue": [
+        "/templates/"
+      ]
+    },
+    {
+      "name": "thymeleaflet.resources.stylesheets",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Stylesheet URLs injected into preview iframes so rendered fragments match the host application.",
+      "defaultValue": []
+    },
+    {
+      "name": "thymeleaflet.resources.scripts",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Script URLs injected into preview iframes for interactive fragment previews.",
+      "defaultValue": []
+    },
+    {
+      "name": "thymeleaflet.resources.cache-duration-seconds",
+      "type": "java.lang.Integer",
+      "description": "Cache duration in seconds for static Thymeleaflet resources.",
+      "defaultValue": 3600
+    },
+    {
+      "name": "thymeleaflet.cache.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Thymeleaflet in-memory caches for fragment discovery, JavaDoc parsing, type extraction, and dependency analysis.",
+      "defaultValue": true
+    },
+    {
+      "name": "thymeleaflet.cache.preload",
+      "type": "java.lang.Boolean",
+      "description": "Warm Thymeleaflet caches at startup when caching is enabled.",
+      "defaultValue": false
+    },
+    {
       "name": "thymeleaflet.preview.background-light",
       "type": "java.lang.String",
       "description": "Light background color for the preview canvas",
@@ -41,6 +79,31 @@
       "name": "thymeleaflet.preview.viewports",
       "type": "java.util.List",
       "description": "Viewport presets (name + width + height), excluding Fit"
+    },
+    {
+      "name": "thymeleaflet.preview.viewports[].id",
+      "type": "java.lang.String",
+      "description": "Stable viewport preset identifier used by the preview control."
+    },
+    {
+      "name": "thymeleaflet.preview.viewports[].label",
+      "type": "java.lang.String",
+      "description": "Human-readable viewport preset label shown in the preview control."
+    },
+    {
+      "name": "thymeleaflet.preview.viewports[].label-key",
+      "type": "java.lang.String",
+      "description": "Message key for localized viewport preset labels."
+    },
+    {
+      "name": "thymeleaflet.preview.viewports[].width",
+      "type": "java.lang.Integer",
+      "description": "Viewport preset width in pixels."
+    },
+    {
+      "name": "thymeleaflet.preview.viewports[].height",
+      "type": "java.lang.Integer",
+      "description": "Viewport preset height in pixels."
     },
     {
       "name": "thymeleaflet.security.auto-permit",

--- a/src/test/java/io/github/wamukat/thymeleaflet/documentation/ConfigurationMetadataCoverageTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/documentation/ConfigurationMetadataCoverageTest.java
@@ -1,0 +1,124 @@
+package io.github.wamukat.thymeleaflet.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.io.InputStream;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationMetadataCoverageTest {
+
+    @Test
+    void springConfigurationMetadata_shouldDescribePrimaryThymeleafletProperties() throws Exception {
+        JsonNode metadata = readMetadata();
+        Map<String, JsonNode> properties = propertiesByName(metadata);
+
+        assertThat(properties.keySet()).contains(
+            "thymeleaflet.enabled",
+            "thymeleaflet.base-path",
+            "thymeleaflet.debug"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.resources.template-paths",
+            "java.util.List<java.lang.String>",
+            "trusted application template locations"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.resources.stylesheets",
+            "java.util.List<java.lang.String>",
+            "Stylesheet URLs injected into preview iframes"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.resources.scripts",
+            "java.util.List<java.lang.String>",
+            "Script URLs injected into preview iframes"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.resources.cache-duration-seconds",
+            "java.lang.Integer",
+            "Cache duration in seconds for static Thymeleaflet resources",
+            "3600"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.cache.enabled",
+            "java.lang.Boolean",
+            "Enable Thymeleaflet in-memory caches",
+            "true"
+        );
+        assertMetadata(
+            properties,
+            "thymeleaflet.cache.preload",
+            "java.lang.Boolean",
+            "Warm Thymeleaflet caches at startup",
+            "false"
+        );
+        assertThat(properties.keySet()).contains(
+            "thymeleaflet.preview.background-light",
+            "thymeleaflet.preview.background-dark",
+            "thymeleaflet.preview.viewports",
+            "thymeleaflet.preview.viewports[].id",
+            "thymeleaflet.preview.viewports[].label",
+            "thymeleaflet.preview.viewports[].label-key",
+            "thymeleaflet.preview.viewports[].width",
+            "thymeleaflet.preview.viewports[].height",
+            "thymeleaflet.security.auto-permit"
+        );
+    }
+
+    private static JsonNode readMetadata() throws Exception {
+        try (InputStream inputStream = ConfigurationMetadataCoverageTest.class.getResourceAsStream(
+            "/META-INF/spring-configuration-metadata.json"
+        )) {
+            assertThat(inputStream).isNotNull();
+            return new ObjectMapper().readTree(inputStream);
+        }
+    }
+
+    private static Map<String, JsonNode> propertiesByName(JsonNode metadata) {
+        Map<String, JsonNode> properties = new LinkedHashMap<>();
+        metadata.path("properties").forEach(property -> properties.put(property.path("name").asText(), property));
+        return properties;
+    }
+
+    private static void assertMetadata(
+        Map<String, JsonNode> properties,
+        String name,
+        String type,
+        String description
+    ) {
+        JsonNode property = requireProperty(properties, name);
+
+        assertThat(property.path("type").asText()).isEqualTo(type);
+        assertThat(property.path("description").asText()).contains(description);
+    }
+
+    private static void assertMetadata(
+        Map<String, JsonNode> properties,
+        String name,
+        String type,
+        String description,
+        String defaultValue
+    ) {
+        JsonNode property = requireProperty(properties, name);
+
+        assertThat(property.path("type").asText()).isEqualTo(type);
+        assertThat(property.path("description").asText()).contains(description);
+        assertThat(property.path("defaultValue").asText()).isEqualTo(defaultValue);
+    }
+
+    private static JsonNode requireProperty(Map<String, JsonNode> properties, String name) {
+        if (!properties.containsKey(name)) {
+            throw new AssertionError("Missing configuration metadata property: " + name);
+        }
+        return properties.get(name);
+    }
+}


### PR DESCRIPTION
## Summary
- Expand Spring configuration metadata for cache, resources, preview viewport items, and security settings.
- Apply thymeleaflet.resources.cache-duration-seconds to Thymeleaflet static css/js/image handlers so metadata matches behavior.
- Add metadata coverage that checks primary entries plus selected type/default/description fields.

## Verification
- `./mvnw -q -Dfrontend.skip=true -Dtest=ConfigurationMetadataCoverageTest,StorybookAutoConfigurationTest,ReadmeVersionConsistencyTest test`
- `./mvnw test -q`
- `npm run test:e2e:local` (Playwright 9/9 passed; known sample shutdown exit 143 after tests)
- `git diff --check`

Refs Kanbalone#460
