### PR TITLE
Clean up local E2E shutdown output

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:starter": "./mvnw -DskipTests install",
     "sample:start": "cd sample && ../mvnw spring-boot:run -DskipTests",
     "test:e2e": "playwright test",
+    "test:e2e:local:unit": "node --test tests/node/run-local-e2e.test.js",
     "test:e2e:local": "node scripts/run-local-e2e.js"
   },
   "devDependencies": {

--- a/scripts/run-local-e2e.js
+++ b/scripts/run-local-e2e.js
@@ -10,24 +10,33 @@ const healthUrl = new URL('/thymeleaflet', baseUrl);
 
 let sampleProcess;
 let stopping = false;
+let shutdownMethod = 'none';
 
 async function main() {
   await runCommand(npmCommand, ['run', 'verify:starter']);
 
   sampleProcess = spawn(npmCommand, ['run', 'sample:start'], {
-    stdio: 'inherit',
+    stdio: ['ignore', 'pipe', 'pipe'],
     detached: !isWindows,
   });
+  forwardSampleOutput(sampleProcess);
 
   sampleProcess.on('exit', (code, signal) => {
+    if (isSuccessfulSampleStop({ stopping, shutdownMethod, code, signal })) {
+      return;
+    }
     if (!stopping) {
       console.error(`sample:start exited before E2E completed (code=${code}, signal=${signal})`);
       process.exitCode = code || 1;
+      return;
     }
+    console.error(`sample:start exited unexpectedly during shutdown (code=${code}, signal=${signal})`);
+    process.exitCode = code || 1;
   });
 
   await waitForSample(healthUrl, 90_000);
   await runCommand(npmCommand, ['run', 'test:e2e']);
+  console.log('\nLocal E2E completed successfully. Stopping sample app...');
 }
 
 function runCommand(command, args) {
@@ -73,14 +82,46 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function forwardSampleOutput(child) {
+  child.stdout?.on('data', (chunk) => {
+    if (shouldForwardSampleOutput(stopping)) {
+      process.stdout.write(chunk);
+    }
+  });
+  child.stderr?.on('data', (chunk) => {
+    if (shouldForwardSampleOutput(stopping)) {
+      process.stderr.write(chunk);
+    }
+  });
+}
+
+function shouldForwardSampleOutput(isStopping) {
+  return !isStopping;
+}
+
+function isSuccessfulSampleStop({ stopping: isStopping, shutdownMethod: method, code, signal }) {
+  if (!isStopping) {
+    return false;
+  }
+  if (method === 'sigterm') {
+    return code === 143 || signal === 'SIGTERM';
+  }
+  if (method === 'taskkill') {
+    return code === 1 || code === 128 || signal === null;
+  }
+  return false;
+}
+
 function stopSample() {
   if (!sampleProcess || sampleProcess.exitCode !== null || stopping) {
     return;
   }
   stopping = true;
   if (isWindows) {
+    shutdownMethod = 'taskkill';
     spawn('taskkill', ['/pid', String(sampleProcess.pid), '/t', '/f'], { stdio: 'ignore' });
   } else {
+    shutdownMethod = 'sigterm';
     process.kill(-sampleProcess.pid, 'SIGTERM');
   }
 }
@@ -95,11 +136,18 @@ process.on('SIGTERM', () => {
   process.exit(143);
 });
 
-main()
-  .catch((error) => {
-    console.error(error.message);
-    process.exitCode = 1;
-  })
-  .finally(() => {
-    stopSample();
-  });
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      stopSample();
+    });
+}
+
+module.exports = {
+  isSuccessfulSampleStop,
+  shouldForwardSampleOutput,
+};

--- a/tests/node/run-local-e2e.test.js
+++ b/tests/node/run-local-e2e.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  shouldForwardSampleOutput,
+  isSuccessfulSampleStop,
+} = require('../../scripts/run-local-e2e');
+
+test('shouldForwardSampleOutput suppresses sample output after expected shutdown starts', () => {
+  assert.equal(shouldForwardSampleOutput(false), true);
+  assert.equal(shouldForwardSampleOutput(true), false);
+});
+
+test('isSuccessfulSampleStop accepts expected termination during shutdown only', () => {
+  assert.equal(isSuccessfulSampleStop({ stopping: true, shutdownMethod: 'sigterm', code: 143, signal: null }), true);
+  assert.equal(isSuccessfulSampleStop({ stopping: true, shutdownMethod: 'sigterm', code: null, signal: 'SIGTERM' }), true);
+  assert.equal(isSuccessfulSampleStop({ stopping: true, shutdownMethod: 'taskkill', code: 1, signal: null }), true);
+  assert.equal(isSuccessfulSampleStop({ stopping: false, shutdownMethod: 'sigterm', code: 143, signal: null }), false);
+  assert.equal(isSuccessfulSampleStop({ stopping: true, shutdownMethod: 'sigterm', code: 1, signal: null }), false);
+  assert.equal(isSuccessfulSampleStop({ stopping: true, shutdownMethod: 'unknown', code: 0, signal: null }), false);
+});


### PR DESCRIPTION
## Summary
- Pipe sample app output through the local E2E helper so expected shutdown output can be suppressed.
- Treat expected SIGTERM/143 and Windows taskkill exits during helper shutdown as successful cleanup.
- Print a clear successful local E2E summary and add focused Node unit coverage for shutdown handling.

## Verification
- `npm run test:e2e:local:unit`
- `node --check scripts/run-local-e2e.js`
- `npm run test:e2e:local` (Playwright 9/9 passed; ended with clear success summary and no Maven BUILD FAILURE shutdown output)
- `git diff --check`

Refs Kanbalone#461
