### PR TITLE
Fix story java.time coercion

### DIFF
--- a/docs/stories.ja.md
+++ b/docs/stories.ja.md
@@ -88,6 +88,50 @@ stories:
 - `model` と `parameters` は同一ストーリーで併用できます。
 - キーが不足すると、Thymeleaf の式は `null` になる可能性があります。
 
+## Java Time 値
+
+Story YAML の値はまず YAML のスカラーとして読み込まれます。JavaDoc で
+パラメータまたはモデルパスに `java.time` 型を宣言している場合、
+Thymeleaflet はレンダリング前に ISO 文字列を対象型へ変換します。
+
+対応型:
+
+- `LocalDate`
+- `LocalDateTime`
+- `LocalTime`
+- `OffsetDateTime`
+- `ZonedDateTime`
+- `Instant`
+
+パラメータ例:
+
+```html
+/**
+ * @param publishedAt {@code java.time.LocalDateTime} [required] 公開日時
+ */
+```
+
+```yaml
+parameters:
+  publishedAt: "2026-04-01T10:00:00"
+```
+
+ネストしたモデルリストの例:
+
+```html
+/**
+ * @model view.items[].publishedAt {@code java.time.LocalDateTime} [required] 公開日時
+ */
+```
+
+```yaml
+model:
+  view:
+    items:
+      - title: お知らせ1
+        publishedAt: "2024-06-01T10:00:00"
+```
+
 ## methodReturns（no-arg）
 
 `methodReturns` を使うと、プレビュー時の no-arg メソッド呼び出し結果を制御できます。

--- a/docs/stories.md
+++ b/docs/stories.md
@@ -88,6 +88,50 @@ stories:
 - `model` and `parameters` can be combined in the same story.
 - If a model key is missing, Thymeleaf expressions may evaluate to `null`.
 
+## Java Time Values
+
+Story YAML values are parsed as YAML scalars first. When JavaDoc declares a
+`java.time` type for a parameter or model path, Thymeleaflet converts ISO string
+values before rendering.
+
+Supported targets:
+
+- `LocalDate`
+- `LocalDateTime`
+- `LocalTime`
+- `OffsetDateTime`
+- `ZonedDateTime`
+- `Instant`
+
+Parameter example:
+
+```html
+/**
+ * @param publishedAt {@code java.time.LocalDateTime} [required] Published date
+ */
+```
+
+```yaml
+parameters:
+  publishedAt: "2026-04-01T10:00:00"
+```
+
+Nested model list example:
+
+```html
+/**
+ * @model view.items[].publishedAt {@code java.time.LocalDateTime} [required] Published date
+ */
+```
+
+```yaml
+model:
+  view:
+    items:
+      - title: Notice 1
+        publishedAt: "2024-06-01T10:00:00"
+```
+
 ## methodReturns (No-arg)
 
 Use `methodReturns` to control no-arg method calls in preview rendering.

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
@@ -33,7 +33,7 @@ public class JavaDocAnalyzer {
     );
 
     private static final Pattern MODEL_PATTERN = Pattern.compile(
-        "@model\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
+        "@model\\s+([\\w.\\[\\]]+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
         Pattern.MULTILINE | Pattern.DOTALL
     );
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
@@ -5,6 +5,7 @@ import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryParame
 import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryRetrievalUseCase;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocAnalyzer;
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.PreviewWarningRecorder;
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.ThymeleafFragmentRenderer;
 import io.github.wamukat.thymeleaflet.infrastructure.web.service.SecurePathConversionService;
@@ -55,6 +56,10 @@ public class FragmentRenderingService {
 
     private final FragmentModelInferenceService fragmentModelInferenceService;
 
+    private final JavaDocLookupService javaDocLookupService;
+
+    private final StoryJavaTimeValueCoercionService storyJavaTimeValueCoercionService;
+
     public FragmentRenderingService(
         ValidationUseCase validationUseCase,
         StoryRetrievalUseCase storyRetrievalUseCase,
@@ -63,7 +68,9 @@ public class FragmentRenderingService {
         ThymeleafFragmentRenderer thymeleafFragmentRenderer,
         MessageSource messageSource,
         ResourceLoader resourceLoader,
-        FragmentModelInferenceService fragmentModelInferenceService
+        FragmentModelInferenceService fragmentModelInferenceService,
+        JavaDocLookupService javaDocLookupService,
+        StoryJavaTimeValueCoercionService storyJavaTimeValueCoercionService
     ) {
         this.validationUseCase = validationUseCase;
         this.storyRetrievalUseCase = storyRetrievalUseCase;
@@ -73,6 +80,8 @@ public class FragmentRenderingService {
         this.messageSource = messageSource;
         this.resourceLoader = resourceLoader;
         this.fragmentModelInferenceService = fragmentModelInferenceService;
+        this.javaDocLookupService = javaDocLookupService;
+        this.storyJavaTimeValueCoercionService = storyJavaTimeValueCoercionService;
     }
 
     /**
@@ -130,6 +139,9 @@ public class FragmentRenderingService {
             logger.debug("Has Story Config: {}", storyInfo.hasStoryConfig());
             logger.debug("Fragment Type: {}", storyInfo.getFragmentSummary().getType());
 
+            Optional<JavaDocAnalyzer.JavaDocInfo> javaDocInfo =
+                javaDocLookupService.findJavaDocInfo(fullTemplatePath, fragmentName);
+
             Map<String, Object> storyModel = storyInfo.getModel();
             if (storyModel.isEmpty()) {
                 storyModel = fragmentModelInferenceService.inferModel(
@@ -174,6 +186,13 @@ public class FragmentRenderingService {
                 logger.debug("Applied methodReturns values: {}", mergedMethodReturns.keySet());
             }
 
+            if (javaDocInfo.isPresent()) {
+                mergedModel = storyJavaTimeValueCoercionService.coerceModel(
+                    mergedModel,
+                    javaDocInfo.orElseThrow()
+                );
+            }
+
             if (!mergedModel.isEmpty()) {
                 for (Map.Entry<String, Object> entry : mergedModel.entrySet()) {
                     model.addAttribute(entry.getKey(), thymeleafFragmentRenderer.resolveTemplateValue(entry.getValue()));
@@ -208,6 +227,12 @@ public class FragmentRenderingService {
             Map<String, Object> mergedParameters = new HashMap<>(parameters);
             if (!parameterOverrides.isEmpty()) {
                 mergedParameters.putAll(parameterOverrides);
+            }
+            if (javaDocInfo.isPresent()) {
+                mergedParameters = storyJavaTimeValueCoercionService.coerceParameters(
+                    mergedParameters,
+                    javaDocInfo.orElseThrow()
+                );
             }
 
             Optional<String> unsafeParameter = findUnsafeFragmentInsertionParameter(

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryJavaTimeValueCoercionService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryJavaTimeValueCoercionService.java
@@ -1,0 +1,229 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocAnalyzer;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class StoryJavaTimeValueCoercionService {
+
+    public Map<String, Object> coerceParameters(
+        Map<String, Object> parameters,
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo
+    ) {
+        Map<String, Object> coerced = deepCopyMap(parameters);
+        for (JavaDocAnalyzer.ParameterInfo parameterInfo : javaDocInfo.getParameters()) {
+            String name = parameterInfo.getName();
+            if (coerced.containsKey(name)) {
+                coerced.put(name, coerceValue(coerced.get(name), parameterInfo.getType(), name));
+            }
+        }
+        return coerced;
+    }
+
+    public Map<String, Object> coerceModel(
+        Map<String, Object> model,
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo
+    ) {
+        Map<String, Object> coerced = deepCopyMap(model);
+        for (JavaDocAnalyzer.ModelInfo modelInfo : javaDocInfo.getModels()) {
+            applyModelPath(coerced, modelInfo.getName(), modelInfo.getType());
+        }
+        return coerced;
+    }
+
+    private void applyModelPath(Map<String, Object> root, String path, String targetType) {
+        if (path.isBlank()) {
+            return;
+        }
+        String[] segments = path.split("\\.");
+        applyPathSegment(root, segments, 0, path, targetType);
+    }
+
+    private @Nullable Object applyPathSegment(
+        @Nullable Object current,
+        String[] segments,
+        int index,
+        String fullPath,
+        String targetType
+    ) {
+        if (current instanceof Map<?, ?> currentMap) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) currentMap;
+            String segment = segments[index];
+            boolean arrayWildcard = segment.endsWith("[]");
+            String key = arrayWildcard ? segment.substring(0, segment.length() - 2) : segment;
+
+            if (!map.containsKey(key)) {
+                return current;
+            }
+
+            if (index == segments.length - 1) {
+                if (arrayWildcard) {
+                    map.put(key, coerceListElements(map.get(key), targetType, fullPath));
+                } else {
+                    map.put(key, coerceValue(map.get(key), targetType, fullPath));
+                }
+                return current;
+            }
+
+            Object next = map.get(key);
+            if (arrayWildcard) {
+                map.put(key, applyToListElements(next, segments, index + 1, fullPath, targetType));
+            } else {
+                map.put(key, applyPathSegment(next, segments, index + 1, fullPath, targetType));
+            }
+            return current;
+        }
+
+        if (current instanceof List<?> currentList) {
+            List<Object> list = new ArrayList<>(currentList.size());
+            for (Object item : currentList) {
+                list.add(applyPathSegment(item, segments, index, fullPath, targetType));
+            }
+            return list;
+        }
+
+        return current;
+    }
+
+    private @Nullable Object applyToListElements(
+        @Nullable Object value,
+        String[] segments,
+        int nextIndex,
+        String fullPath,
+        String targetType
+    ) {
+        if (!(value instanceof List<?> listValue)) {
+            return value;
+        }
+        List<Object> coerced = new ArrayList<>(listValue.size());
+        for (Object item : listValue) {
+            coerced.add(applyPathSegment(item, segments, nextIndex, fullPath, targetType));
+        }
+        return coerced;
+    }
+
+    private @Nullable Object coerceListElements(@Nullable Object value, String targetType, String path) {
+        if (!(value instanceof List<?> listValue)) {
+            return value;
+        }
+        List<Object> coerced = new ArrayList<>(listValue.size());
+        for (Object item : listValue) {
+            coerced.add(coerceValue(item, targetType, path));
+        }
+        return coerced;
+    }
+
+    private @Nullable Object coerceValue(@Nullable Object value, String targetType, String path) {
+        Optional<JavaTimeTarget> javaTimeTarget = JavaTimeTarget.fromTypeName(targetType);
+        if (javaTimeTarget.isEmpty() || value == null || !(value instanceof String stringValue)) {
+            return value;
+        }
+        try {
+            return javaTimeTarget.orElseThrow().parse(stringValue);
+        } catch (DateTimeParseException e) {
+            throw new StoryValueCoercionException(
+                "Failed to convert story value '%s' with value '%s' to %s"
+                    .formatted(path, stringValue, targetType),
+                e
+            );
+        }
+    }
+
+    private Map<String, Object> deepCopyMap(Map<String, Object> source) {
+        Map<String, Object> copied = new HashMap<>();
+        source.forEach((key, value) -> copied.put(key, deepCopyValue(value)));
+        return copied;
+    }
+
+    private @Nullable Object deepCopyValue(@Nullable Object value) {
+        if (value instanceof Map<?, ?> mapValue) {
+            Map<String, Object> copied = new HashMap<>();
+            mapValue.forEach((key, childValue) -> copied.put(String.valueOf(key), deepCopyValue(childValue)));
+            return copied;
+        }
+        if (value instanceof List<?> listValue) {
+            List<Object> copied = new ArrayList<>(listValue.size());
+            listValue.forEach(item -> copied.add(deepCopyValue(item)));
+            return copied;
+        }
+        return value;
+    }
+
+    private enum JavaTimeTarget {
+        LOCAL_DATE("LocalDate") {
+            @Override
+            Object parse(String value) {
+                return LocalDate.parse(value);
+            }
+        },
+        LOCAL_DATE_TIME("LocalDateTime") {
+            @Override
+            Object parse(String value) {
+                return LocalDateTime.parse(value);
+            }
+        },
+        LOCAL_TIME("LocalTime") {
+            @Override
+            Object parse(String value) {
+                return LocalTime.parse(value);
+            }
+        },
+        OFFSET_DATE_TIME("OffsetDateTime") {
+            @Override
+            Object parse(String value) {
+                return OffsetDateTime.parse(value);
+            }
+        },
+        ZONED_DATE_TIME("ZonedDateTime") {
+            @Override
+            Object parse(String value) {
+                return ZonedDateTime.parse(value);
+            }
+        },
+        INSTANT("Instant") {
+            @Override
+            Object parse(String value) {
+                return Instant.parse(value);
+            }
+        };
+
+        private final String simpleName;
+
+        JavaTimeTarget(String simpleName) {
+            this.simpleName = simpleName;
+        }
+
+        abstract Object parse(String value);
+
+        static Optional<JavaTimeTarget> fromTypeName(String typeName) {
+            String normalized = typeName.strip();
+            for (JavaTimeTarget target : values()) {
+                if (normalized.equals(target.simpleName) || normalized.equals("java.time." + target.simpleName)) {
+                    return Optional.of(target);
+                }
+            }
+            return Optional.empty();
+        }
+    }
+
+    public static class StoryValueCoercionException extends RuntimeException {
+        public StoryValueCoercionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
@@ -301,6 +301,34 @@ class JavaDocAnalyzerTest {
     }
 
     @Test
+    @DisplayName("@modelタグでドットと配列ワイルドカードを含むパスを解析できる")
+    void shouldParseModelPathWithDotsAndArrayWildcard() {
+        // Given
+        String htmlContent = """
+            <!--
+            /**
+             * お知らせ一覧
+             *
+             * @fragment noticeList
+             * @model view.items[].publishedAt {@code java.time.LocalDateTime} [required] 公開日時
+             */
+            -->
+            <section th:fragment="noticeList">List</section>
+            """;
+
+        // When
+        List<JavaDocAnalyzer.JavaDocInfo> result = analyzer.analyzeJavaDocFromHtml(htmlContent);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getModels()).singleElement()
+            .satisfies(model -> {
+                assertThat(model.getName()).isEqualTo("view.items[].publishedAt");
+                assertThat(model.getType()).isEqualTo("java.time.LocalDateTime");
+            });
+    }
+
+    @Test
     @DisplayName("@exampleタグでth:blockと引数なしフラグメントを解析できる")
     void shouldParseThBlockAndNoArgumentExamples() {
         // Given

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
@@ -62,6 +62,42 @@ class ThymeleafletRenderingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    @DisplayName("JavaDoc @param の java.time 型に基づいて story parameters を変換して描画する")
+    void shouldRenderJavaTimeParameterValuesFromStoryYaml() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/test.java-time-story/detailHeader/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Campaign"), "通常の String パラメータはそのまま描画されること");
+        assertTrue(body.contains("2026-04-01 10:00"),
+            "LocalDateTime パラメータを #temporals.format で描画できること");
+        assertFalse(body.contains("Preview error"),
+            "java.time 変換によりプレビューエラーにならないこと");
+    }
+
+    @Test
+    @DisplayName("JavaDoc @model の [] パスに基づいて story model 内の java.time 値を変換して描画する")
+    void shouldRenderJavaTimeModelListValuesFromStoryYaml() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/test.java-time-story/noticeList/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Notice 1"), "model の通常フィールドはそのまま描画されること");
+        assertTrue(body.contains("2024-06-01 10:00"),
+            "list 内の LocalDateTime フィールドを #temporals.format で描画できること");
+        assertTrue(body.contains("2024-06-02 11:30"),
+            "[] パスが list の全要素に適用されること");
+        assertFalse(body.contains("Preview error"),
+            "java.time 変換によりプレビューエラーにならないこと");
+    }
+
+    @Test
     @DisplayName("Map no-arg メソッドが未解決でも /render は継続し警告ヘッダーを返す")
     void shouldRenderWithWarningsForUnresolvedMapNoArgMethods() throws Exception {
         var mvcResult = mockMvc.perform(get("/thymeleaflet/test.map-noarg-warning/methodWarning/default/render")

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryJavaTimeValueCoercionServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/StoryJavaTimeValueCoercionServiceTest.java
@@ -1,0 +1,113 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation.JavaDocAnalyzer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("StoryJavaTimeValueCoercionService Tests")
+class StoryJavaTimeValueCoercionServiceTest {
+
+    private final StoryJavaTimeValueCoercionService service = new StoryJavaTimeValueCoercionService();
+
+    @Test
+    @DisplayName("@param の java.time.LocalDateTime 型に合わせて parameters の ISO 文字列を変換する")
+    void shouldCoerceLocalDateTimeParameterFromJavaDocParamType() {
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "Detail header",
+            List.of(JavaDocAnalyzer.ParameterInfo.required("publishedAt", "java.time.LocalDateTime", "公開日時")),
+            List.of(),
+            Optional.empty()
+        );
+
+        Map<String, Object> result = service.coerceParameters(
+            Map.of("publishedAt", "2026-04-01T10:00:00", "title", "Campaign"),
+            javaDocInfo
+        );
+
+        assertThat(result.get("publishedAt")).isEqualTo(LocalDateTime.of(2026, 4, 1, 10, 0));
+        assertThat(result.get("title")).isEqualTo("Campaign");
+    }
+
+    @Test
+    @DisplayName("@model の [] パスに合わせて list 内の model フィールドを変換する")
+    void shouldCoerceNestedListModelValuesFromJavaDocModelPath() {
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "List",
+            List.of(),
+            List.of(JavaDocAnalyzer.ModelInfo.required(
+                "view.items[].publishedAt",
+                "LocalDateTime",
+                "公開日時"
+            )),
+            List.of(),
+            Optional.empty()
+        );
+        Map<String, Object> model = Map.of(
+            "view",
+            Map.of(
+                "items",
+                List.of(
+                    Map.of("title", "Notice 1", "publishedAt", "2024-06-01T10:00:00"),
+                    Map.of("title", "Notice 2", "publishedAt", "2024-06-02T11:30:00")
+                )
+            )
+        );
+
+        Map<String, Object> result = service.coerceModel(model, javaDocInfo);
+
+        assertThat(result.get("view")).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> view = (Map<String, Object>) Objects.requireNonNull(result.get("view"));
+        assertThat(view.get("items")).isInstanceOf(List.class);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) Objects.requireNonNull(view.get("items"));
+        assertThat(items)
+            .extracting(item -> item.get("publishedAt"))
+            .containsExactly(
+                LocalDateTime.of(2024, 6, 1, 10, 0),
+                LocalDateTime.of(2024, 6, 2, 11, 30)
+            );
+        assertThat(items).extracting(item -> item.get("title")).containsExactly("Notice 1", "Notice 2");
+    }
+
+    @Test
+    @DisplayName("java.time 以外の型は既存値を変更しない")
+    void shouldLeaveUnsupportedTypesUnchanged() {
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "Detail header",
+            List.of(JavaDocAnalyzer.ParameterInfo.required("title", "String", "タイトル")),
+            List.of(),
+            Optional.empty()
+        );
+
+        Map<String, Object> result = service.coerceParameters(Map.of("title", "Campaign"), javaDocInfo);
+
+        assertThat(result).containsEntry("title", "Campaign");
+    }
+
+    @Test
+    @DisplayName("java.time 型の不正な値は対象 path と型が分かる例外にする")
+    void shouldReportClearErrorForInvalidJavaTimeValue() {
+        JavaDocAnalyzer.JavaDocInfo javaDocInfo = JavaDocAnalyzer.JavaDocInfo.of(
+            "Detail header",
+            List.of(JavaDocAnalyzer.ParameterInfo.required("publishedAt", "java.time.LocalDateTime", "公開日時")),
+            List.of(),
+            Optional.empty()
+        );
+
+        assertThatThrownBy(() -> service.coerceParameters(Map.of("publishedAt", "not-a-date"), javaDocInfo))
+            .isInstanceOf(StoryJavaTimeValueCoercionService.StoryValueCoercionException.class)
+            .hasMessageContaining("publishedAt")
+            .hasMessageContaining("java.time.LocalDateTime")
+            .hasMessageContaining("not-a-date");
+    }
+}

--- a/src/test/resources/META-INF/thymeleaflet/stories/test/java-time-story.stories.yml
+++ b/src/test/resources/META-INF/thymeleaflet/stories/test/java-time-story.stories.yml
@@ -1,0 +1,19 @@
+storyGroups:
+  detailHeader:
+    stories:
+      - name: default
+        title: Default
+        parameters:
+          title: Campaign
+          publishedAt: "2026-04-01T10:00:00"
+  noticeList:
+    stories:
+      - name: default
+        title: Default
+        model:
+          view:
+            items:
+              - title: Notice 1
+                publishedAt: "2024-06-01T10:00:00"
+              - title: Notice 2
+                publishedAt: "2024-06-02T11:30:00"

--- a/src/test/resources/templates/test/java-time-story.html
+++ b/src/test/resources/templates/test/java-time-story.html
@@ -1,0 +1,28 @@
+<!--
+/**
+ * Detail header with Java time parameter.
+ *
+ * @fragment detailHeader
+ * @param title {@code String} [required] Title
+ * @param publishedAt {@code java.time.LocalDateTime} [required] Published date
+ */
+-->
+<th:block th:fragment="detailHeader(title, publishedAt)">
+  <h2 th:text="${title}">Title</h2>
+  <p th:text="${#temporals.format(publishedAt, 'yyyy-MM-dd HH:mm')}">Date</p>
+</th:block>
+
+<!--
+/**
+ * Notice list with Java time model values.
+ *
+ * @fragment noticeList
+ * @model view.items[].publishedAt {@code java.time.LocalDateTime} [required] Published date
+ */
+-->
+<section th:fragment="noticeList()">
+  <article th:each="item : ${view.items}">
+    <h3 th:text="${item.title}">Notice</h3>
+    <time th:text="${#temporals.format(item.publishedAt, 'yyyy-MM-dd HH:mm')}">Date</time>
+  </article>
+</section>


### PR DESCRIPTION
## Summary

- Convert story YAML `java.time` parameter values from JavaDoc `@param` type metadata before rendering
- Convert nested story `model` values using JavaDoc `@model` paths such as `view.items[].publishedAt`
- Expand `@model` parsing to support dotted paths and `[]` list wildcards
- Document supported Java time story values in English and Japanese docs

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=JavaDocAnalyzerTest,StoryJavaTimeValueCoercionServiceTest test`
- `./mvnw -q -Dfrontend.skip=true -Dtest=ThymeleafletRenderingExceptionHandlerIntegrationTest,JavaDocAnalyzerTest,StoryJavaTimeValueCoercionServiceTest test`
- `./mvnw test -q`
- `npm run test:workflow`
- `npm run test:e2e:local` passed on retry; first attempt timed out while sample npm/build setup was still running

Closes #137
