### PR TITLE
Fix story rendering regressions

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -13,6 +13,7 @@ import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.domain.service.StoryDataRepository;
 import io.github.wamukat.thymeleaflet.domain.service.StoryParameterDomainService;
 import io.github.wamukat.thymeleaflet.domain.service.TemplateModelExpressionAnalyzer;
+import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.NoArgFragmentReferencePreProcessorDialect;
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.ThymeleafletAwareThymeleafView;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -39,6 +40,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
+import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.spring6.view.ThymeleafViewResolver;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
@@ -125,6 +127,12 @@ public class StorybookAutoConfiguration {
         resolver.setOrder(0);
         resolver.setCheckExistence(false);
         return resolver;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "thymeleafletNoArgFragmentReferenceDialect")
+    public IDialect thymeleafletNoArgFragmentReferenceDialect() {
+        return new NoArgFragmentReferencePreProcessorDialect();
     }
 
     /**

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
@@ -1,0 +1,64 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.rendering;
+
+import org.thymeleaf.engine.AbstractTemplateHandler;
+import org.thymeleaf.model.IAttribute;
+import org.thymeleaf.model.IOpenElementTag;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.model.IStandaloneElementTag;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHandler {
+
+    private static final Pattern NO_ARG_FRAGMENT_SELECTOR =
+        Pattern.compile("(::\\s*)('?)([A-Za-z0-9_-]+)\\s*\\(\\s*\\)('?)");
+
+    @Override
+    public void handleOpenElement(IOpenElementTag tag) {
+        getNext().handleOpenElement(normalizeFragmentInsertionAttributes(tag));
+    }
+
+    @Override
+    public void handleStandaloneElement(IStandaloneElementTag tag) {
+        getNext().handleStandaloneElement(normalizeFragmentInsertionAttributes(tag));
+    }
+
+    private <T extends IProcessableElementTag> T normalizeFragmentInsertionAttributes(T tag) {
+        T updated = tag;
+        for (IAttribute attribute : tag.getAllAttributes()) {
+            String value = attribute.getValue();
+            if (!isFragmentInsertionAttribute(attribute) || value == null) {
+                continue;
+            }
+
+            String normalized = normalizeNoArgFragmentSelector(value);
+            if (normalized.equals(value)) {
+                continue;
+            }
+
+            updated = getContext().getModelFactory().replaceAttribute(
+                updated,
+                attribute.getAttributeDefinition().getAttributeName(),
+                attribute.getAttributeCompleteName(),
+                normalized,
+                attribute.getValueQuotes()
+            );
+        }
+        return updated;
+    }
+
+    static String normalizeNoArgFragmentSelector(String value) {
+        Matcher matcher = NO_ARG_FRAGMENT_SELECTOR.matcher(value);
+        return matcher.replaceAll("$1$2$3$4");
+    }
+
+    private static boolean isFragmentInsertionAttribute(IAttribute attribute) {
+        String attributeName = attribute.getAttributeCompleteName().toLowerCase(Locale.ROOT);
+        return attributeName.equals("th:replace")
+            || attributeName.equals("th:insert")
+            || attributeName.equals("data-th-replace")
+            || attributeName.equals("data-th-insert");
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessorDialect.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessorDialect.java
@@ -1,0 +1,32 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.rendering;
+
+import org.thymeleaf.dialect.AbstractDialect;
+import org.thymeleaf.dialect.IPreProcessorDialect;
+import org.thymeleaf.preprocessor.IPreProcessor;
+import org.thymeleaf.preprocessor.PreProcessor;
+import org.thymeleaf.templatemode.TemplateMode;
+
+import java.util.Set;
+
+public final class NoArgFragmentReferencePreProcessorDialect
+    extends AbstractDialect
+    implements IPreProcessorDialect {
+
+    public NoArgFragmentReferencePreProcessorDialect() {
+        super("thymeleaflet-no-arg-fragment-reference");
+    }
+
+    @Override
+    public int getDialectPreProcessorPrecedence() {
+        return 1000;
+    }
+
+    @Override
+    public Set<IPreProcessor> getPreProcessors() {
+        return Set.of(new PreProcessor(
+            TemplateMode.HTML,
+            NoArgFragmentReferencePreProcessor.class,
+            1000
+        ));
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
@@ -98,6 +98,22 @@ class ThymeleafletRenderingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    @DisplayName("パラメータなしフラグメント参照の name() 形式をプレビューで解決できる")
+    void shouldRenderNoArgFragmentReferenceWithEmptyParentheses() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/test.no-arg-fragment-reference/shell/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Topbar OK"),
+            "別テンプレートの no-arg fragment を name() 形式で参照しても描画できること");
+        assertFalse(body.contains("Preview error"),
+            "no-arg fragment 参照によりプレビューエラーにならないこと");
+    }
+
+    @Test
     @DisplayName("Map no-arg メソッドが未解決でも /render は継続し警告ヘッダーを返す")
     void shouldRenderWithWarningsForUnresolvedMapNoArgMethods() throws Exception {
         var mvcResult = mockMvc.perform(get("/thymeleaflet/test.map-noarg-warning/methodWarning/default/render")

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessorTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessorTest.java
@@ -1,0 +1,40 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.rendering;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NoArgFragmentReferencePreProcessorTest {
+
+    @Test
+    void shouldNormalizeNoArgFragmentSelector() {
+        String normalized = NoArgFragmentReferencePreProcessor.normalizeNoArgFragmentSelector(
+            "~{components/topbar :: topbar()}"
+        );
+
+        assertEquals("~{components/topbar :: topbar}", normalized);
+    }
+
+    @Test
+    void shouldNormalizeQuotedNoArgFragmentSelector() {
+        String normalized = NoArgFragmentReferencePreProcessor.normalizeNoArgFragmentSelector(
+            "~{'components/topbar' :: 'topbar()'}"
+        );
+
+        assertEquals("~{'components/topbar' :: 'topbar'}", normalized);
+    }
+
+    @Test
+    void shouldKeepPositionalParameterizedFragmentSelector() {
+        String value = "~{components/button :: button(label)}";
+
+        assertEquals(value, NoArgFragmentReferencePreProcessor.normalizeNoArgFragmentSelector(value));
+    }
+
+    @Test
+    void shouldKeepNamedParameterizedFragmentSelector() {
+        String value = "~{components/button :: button(label=${label})}";
+
+        assertEquals(value, NoArgFragmentReferencePreProcessor.normalizeNoArgFragmentSelector(value));
+    }
+}

--- a/src/test/resources/META-INF/thymeleaflet/stories/test/no-arg-fragment-reference.stories.yml
+++ b/src/test/resources/META-INF/thymeleaflet/stories/test/no-arg-fragment-reference.stories.yml
@@ -1,0 +1,5 @@
+storyGroups:
+  shell:
+    stories:
+      - name: default
+        title: Default

--- a/src/test/resources/templates/test/no-arg-fragment-reference.html
+++ b/src/test/resources/templates/test/no-arg-fragment-reference.html
@@ -1,0 +1,11 @@
+<!--
+/**
+ * Shell fragment that references a no-arg fragment from another template.
+ *
+ * @fragment shell
+ */
+-->
+<section th:fragment="shell">
+  <div th:replace="~{test/no-arg-fragment-target :: topbar()}"></div>
+  <main>No-arg reference shell</main>
+</section>

--- a/src/test/resources/templates/test/no-arg-fragment-target.html
+++ b/src/test/resources/templates/test/no-arg-fragment-target.html
@@ -1,0 +1,3 @@
+<header th:fragment="topbar">
+  Topbar OK
+</header>


### PR DESCRIPTION
## Summary

- Fix preview rendering for no-arg fragment references written as `fragmentName()` when the target fragment is declared without parameters.
- Add a narrow Thymeleaf preprocessor dialect that normalizes only empty-argument fragment selectors, including quoted selector syntax.
- Keep GH#148 covered by the existing Java time story model conversion regression tests.

## Verification

- `./mvnw -q -Dfrontend.skip=true -Dtest=NoArgFragmentReferencePreProcessorTest,ThymeleafletRenderingExceptionHandlerIntegrationTest#shouldRenderNoArgFragmentReferenceWithEmptyParentheses test`
- `./mvnw -q -Dfrontend.skip=true -Dtest=ThymeleafletRenderingExceptionHandlerIntegrationTest,StoryJavaTimeValueCoercionServiceTest test`
- `./mvnw -q -Dfrontend.skip=true test`
- `./mvnw -q -DskipTests install`
- sample app started on port 6006
- `npm run test:e2e` (9 passed)

Closes #148
Closes #149
