### PR TITLE
Prepare release 0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.20] - 2026-05-02
+
+- Fixed
+  - Normalized no-argument fragment references such as `topbar()` to `topbar` during Thymeleaflet preview rendering, allowing templates that use Spring MVC-compatible no-arg fragment call syntax to render without preview-only fragment resolution failures. (#149)
+  - Preserved Story YAML Java time model conversion regression coverage for `@model` list paths such as `view.items[].publishedAt`, confirming YAML ISO strings continue to render through `#temporals.format`. (#148)
+- Test
+  - Added preview regression coverage for no-arg fragment references declared without parameters and referenced with `name()`.
+  - Added unit coverage for quoted no-arg selectors and for leaving positional/named parameterized fragment references unchanged.
+- Build
+  - Updated Maven project, sample app, and README dependency examples to `0.2.20`.
+
+### Issues
+
+- #148 ストーリーデータが String 型の場合、#temporals.format() が EL1004E で失敗する
+- #149 パラメータなしフラグメントを topbar() 形式で参照するとプレビューで解決失敗する
+
 ## [0.2.19] - 2026-05-01
 
 - Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.19</version>
+  <version>0.2.20</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.19")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.20")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.19</version>
+  <version>0.2.20</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.19")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.20")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.19</version>
+    <version>0.2.20</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.19</version>
+    <version>0.2.20</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.19</version>
+            <version>0.2.20</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

- Prepare `0.2.20` release metadata.
- Update root/sample Maven versions and README dependency examples to `0.2.20`.
- Add CHANGELOG entries for the GH#148/GH#149 story rendering fixes merged after `v0.2.19`.

## Verification

- `./mvnw test -q`
- `npm run test:e2e:local` (9 passed)
- confirmed no sample app remained listening on port `6006`

Closes: N/A
