### PR TITLE
Prepare release 0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.21] - 2026-05-02
+
+- Changed
+  - Replaced fragile regex-only template attribute extraction with a structured parser abstraction backed by Thymeleaf-compatible parsing, then migrated model inference and JavaDoc analysis to the shared parser path. (Kanbalone #479, #480)
+  - Added a Thymeleaf expression tokenizer for model path inference, improving handling of utility calls, static class paths, aliases, reserved words, and unsupported dynamic bracket expressions. (Kanbalone #481)
+- Fixed
+  - Applied Java time Story YAML conversion to nested list model paths such as `view.someObject.items[].publishedAt`, so `#temporals.format` can render nested collection values from story data. (#153)
+- Docs
+  - Documented the template parsing architecture, supported syntax, and parser tradeoffs in English and Japanese documentation. (Kanbalone #483)
+- Test
+  - Added parser regression fixtures based on recent defects, including no-arg fragment references, quoted selectors, nested Java time paths, and child model inference. (Kanbalone #482)
+  - Added direct story diagnostic mapping tests plus template rendering coverage to ensure `code` and `userSafeMessage` are shown while `developerMessage` remains hidden. (Kanbalone #211, #212)
+  - Added local E2E coverage for malformed `.stories.yml` files showing a user-safe Story YAML diagnostic without changing existing snapshot baselines. (Kanbalone #213)
+- Build
+  - Updated Maven project, sample app, and README dependency examples to `0.2.21`.
+
+### Issues
+
+- #153 `#148` fix does not apply to nested list paths such as `view.someObject.items[].publishedAt`
+- Kanbalone #211 Story diagnostics mapping direct tests
+- Kanbalone #212 Story diagnostics template display tests
+- Kanbalone #213 Broken `.stories.yml` UI diagnostic E2E
+- Kanbalone #477 Roadmap: replace fragile template parsing with structured parsing
+- Kanbalone #479 Structured template parser abstraction
+- Kanbalone #480 Template model analyzer structured extraction migration
+- Kanbalone #481 Thymeleaf expression tokenizer for model path inference
+- Kanbalone #482 Parser regression fixture corpus
+- Kanbalone #483 Template parsing architecture documentation
+
 ## [0.2.20] - 2026-05-02
 
 - Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.20</version>
+  <version>0.2.21</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.20")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.21")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.20</version>
+  <version>0.2.21</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.20")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.21")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.20</version>
+    <version>0.2.21</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.20</version>
+    <version>0.2.21</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.20</version>
+            <version>0.2.21</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

Prepare release 0.2.21.

## Changes

- Update Maven project and sample versions to 0.2.21.
- Update README dependency examples in English and Japanese.
- Add 0.2.21 changelog entries for structured template parsing, nested Java time Story YAML conversion, parser regressions, story diagnostic tests, and malformed Story YAML E2E coverage.

## Verification

- ./mvnw test -q
- npm run test:e2e:local

Closes: N/A
