### PR TITLE
Refactor structured template parsing hotspots

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
@@ -8,8 +8,11 @@ import org.attoparser.config.ParseConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Internal parser facade for template-level extraction that should match Thymeleaf's HTML parser.
@@ -33,12 +36,61 @@ public class StructuredTemplateParser {
             textNodes = List.copyOf(textNodes);
             comments = List.copyOf(comments);
         }
+
+        public List<TemplateElement> subtree(TemplateElement root) {
+            Objects.requireNonNull(root, "root cannot be null");
+            Map<Integer, TemplateElement> byIndex = elements.stream()
+                .collect(Collectors.toUnmodifiableMap(TemplateElement::index, element -> element));
+            return elements.stream()
+                .filter(element -> element.index() == root.index() || isDescendantOf(element, root.index(), byIndex))
+                .toList();
+        }
+
+        public List<TemplateElement> elementsMatchingSubtree(Predicate<TemplateElement> rootPredicate) {
+            Objects.requireNonNull(rootPredicate, "rootPredicate cannot be null");
+            return elements.stream()
+                .filter(rootPredicate)
+                .findFirst()
+                .map(this::subtree)
+                .orElse(elements);
+        }
+
+        private static boolean isDescendantOf(
+            TemplateElement candidate,
+            int rootIndex,
+            Map<Integer, TemplateElement> byIndex
+        ) {
+            int parentIndex = candidate.parentIndex();
+            while (parentIndex >= 0) {
+                if (parentIndex == rootIndex) {
+                    return true;
+                }
+                TemplateElement parent = byIndex.get(parentIndex);
+                if (parent == null) {
+                    return false;
+                }
+                parentIndex = parent.parentIndex();
+            }
+            return false;
+        }
     }
 
-    public record TemplateElement(String name, List<TemplateAttribute> attributes, int line, int column) {
+    public record TemplateElement(
+        String name,
+        List<TemplateAttribute> attributes,
+        int line,
+        int column,
+        int index,
+        int parentIndex,
+        int depth
+    ) {
         public TemplateElement {
             name = name.trim();
             attributes = List.copyOf(attributes);
+        }
+
+        public TemplateElement(String name, List<TemplateAttribute> attributes, int line, int column) {
+            this(name, attributes, line, column, -1, -1, 0);
         }
 
         public Optional<String> attributeValue(String attributeName) {
@@ -77,6 +129,7 @@ public class StructuredTemplateParser {
     private static final class CollectingMarkupHandler extends AbstractMarkupHandler {
 
         private final List<MutableTemplateElement> elements = new ArrayList<>();
+        private final List<Integer> openElementStack = new ArrayList<>();
         private final List<TemplateText> textNodes = new ArrayList<>();
         private final List<TemplateComment> comments = new ArrayList<>();
         private Optional<MutableTemplateElement> currentElement = Optional.empty();
@@ -112,6 +165,7 @@ public class StructuredTemplateParser {
             int line,
             int col
         ) {
+            currentElement.ifPresent(element -> openElementStack.add(element.index));
             currentElement = Optional.empty();
         }
 
@@ -125,6 +179,28 @@ public class StructuredTemplateParser {
             int col
         ) {
             currentElement = Optional.empty();
+        }
+
+        @Override
+        public void handleCloseElementStart(
+            char[] buffer,
+            int nameOffset,
+            int nameLen,
+            int line,
+            int col
+        ) {
+            closeElement(buffer, nameOffset, nameLen);
+        }
+
+        @Override
+        public void handleAutoCloseElementStart(
+            char[] buffer,
+            int nameOffset,
+            int nameLen,
+            int line,
+            int col
+        ) {
+            closeElement(buffer, nameOffset, nameLen);
         }
 
         @Override
@@ -179,9 +255,29 @@ public class StructuredTemplateParser {
         }
 
         private void startElement(char[] buffer, int nameOffset, int nameLen, int line, int col) {
-            MutableTemplateElement element = new MutableTemplateElement(slice(buffer, nameOffset, nameLen), line, col);
+            int index = elements.size();
+            int parentIndex = openElementStack.isEmpty() ? -1 : openElementStack.get(openElementStack.size() - 1);
+            MutableTemplateElement element = new MutableTemplateElement(
+                slice(buffer, nameOffset, nameLen),
+                line,
+                col,
+                index,
+                parentIndex,
+                openElementStack.size()
+            );
             elements.add(element);
             currentElement = Optional.of(element);
+        }
+
+        private void closeElement(char[] buffer, int nameOffset, int nameLen) {
+            String name = slice(buffer, nameOffset, nameLen);
+            for (int index = openElementStack.size() - 1; index >= 0; index--) {
+                MutableTemplateElement openElement = elements.get(openElementStack.get(index));
+                openElementStack.remove(index);
+                if (openElement.name.equalsIgnoreCase(name)) {
+                    return;
+                }
+            }
         }
 
         private ParsedTemplate toParsedTemplate() {
@@ -204,16 +300,22 @@ public class StructuredTemplateParser {
         private final String name;
         private final int line;
         private final int column;
+        private final int index;
+        private final int parentIndex;
+        private final int depth;
         private final List<TemplateAttribute> attributes = new ArrayList<>();
 
-        private MutableTemplateElement(String name, int line, int column) {
+        private MutableTemplateElement(String name, int line, int column, int index, int parentIndex, int depth) {
             this.name = name;
             this.line = line;
             this.column = column;
+            this.index = index;
+            this.parentIndex = parentIndex;
+            this.depth = depth;
         }
 
         private TemplateElement toTemplateElement() {
-            return new TemplateElement(name, attributes, line, column);
+            return new TemplateElement(name, attributes, line, column, index, parentIndex, depth);
         }
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -12,15 +12,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * テンプレート式を解析し、モデル推論に必要な情報を抽出する。
  */
 public class TemplateModelExpressionAnalyzer {
 
-    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{([^}]*)}");
     private static final Set<String> RESERVED_ROOTS = Set.of(
         "true", "false", "null",
         "param", "session", "application", "request", "response",
@@ -52,9 +49,7 @@ public class TemplateModelExpressionAnalyzer {
     private List<ModelPath> extractModelPathsFromSources(List<String> sources, Set<String> excludedIdentifiers) {
         List<ModelPath> paths = new ArrayList<>();
         for (String source : sources) {
-            Matcher matcher = EXPRESSION_PATTERN.matcher(source);
-            while (matcher.find()) {
-                String expression = matcher.group(1);
+            for (String expression : extractExpressionBodies(source)) {
                 for (List<String> path : extractModelPaths(expression, excludedIdentifiers)) {
                     paths.add(ModelPath.of(path));
                 }
@@ -66,9 +61,7 @@ public class TemplateModelExpressionAnalyzer {
     private List<ModelPath> extractNoArgMethodPathsFromSources(List<String> sources, Set<String> excludedIdentifiers) {
         LinkedHashSet<ModelPath> methodPaths = new LinkedHashSet<>();
         for (String source : sources) {
-            Matcher matcher = EXPRESSION_PATTERN.matcher(source);
-            while (matcher.find()) {
-                String expression = matcher.group(1);
+            for (String expression : extractExpressionBodies(source)) {
                 List<List<String>> extracted = new ArrayList<>();
                 extractModelPaths(expression, excludedIdentifiers, extracted);
                 for (List<String> path : extracted) {
@@ -77,6 +70,65 @@ public class TemplateModelExpressionAnalyzer {
             }
         }
         return new ArrayList<>(methodPaths);
+    }
+
+    private List<String> extractExpressionBodies(String source) {
+        List<String> expressions = new ArrayList<>();
+        int index = 0;
+        while (index < source.length() - 1) {
+            char current = source.charAt(index);
+            if ((current != '$' && current != '*') || source.charAt(index + 1) != '{') {
+                index++;
+                continue;
+            }
+            Optional<ExpressionBody> expressionBody = readExpressionBody(source, index + 2);
+            if (expressionBody.isEmpty()) {
+                index += 2;
+                continue;
+            }
+            ExpressionBody resolvedBody = expressionBody.orElseThrow();
+            expressions.add(resolvedBody.content());
+            index = resolvedBody.nextIndex();
+        }
+        return expressions;
+    }
+
+    private Optional<ExpressionBody> readExpressionBody(String source, int bodyStart) {
+        int depthBrace = 1;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean escaped = false;
+        for (int index = bodyStart; index < source.length(); index++) {
+            char current = source.charAt(index);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (current == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (current == '\'' && !inDoubleQuote) {
+                inSingleQuote = !inSingleQuote;
+                continue;
+            }
+            if (current == '"' && !inSingleQuote) {
+                inDoubleQuote = !inDoubleQuote;
+                continue;
+            }
+            if (inSingleQuote || inDoubleQuote) {
+                continue;
+            }
+            if (current == '{') {
+                depthBrace++;
+            } else if (current == '}') {
+                depthBrace--;
+                if (depthBrace == 0) {
+                    return Optional.of(new ExpressionBody(source.substring(bodyStart, index), index + 1));
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private List<List<String>> extractModelPaths(String expression, Set<String> excludedIdentifiers) {
@@ -378,6 +430,9 @@ public class TemplateModelExpressionAnalyzer {
         HASH,
         AT,
         OTHER
+    }
+
+    private record ExpressionBody(String content, int nextIndex) {
     }
 
     private record ExpressionToken(ExpressionTokenType type, String text) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParser.java
@@ -1,28 +1,43 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class FragmentDefinitionParser {
 
-    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
-        "th:fragment\\s*=\\s*[\"']([^\"']+)[\"']"
-    );
+    private static final Set<String> FRAGMENT_ATTRIBUTES = Set.of("th:fragment", "data-th-fragment");
+
+    private final StructuredTemplateParser templateParser;
+
+    public FragmentDefinitionParser() {
+        this(new StructuredTemplateParser());
+    }
+
+    FragmentDefinitionParser(StructuredTemplateParser templateParser) {
+        this.templateParser = templateParser;
+    }
 
     public List<FragmentDefinition> parseTemplate(String templatePath, String content) {
         Objects.requireNonNull(templatePath, "templatePath cannot be null");
         Objects.requireNonNull(content, "content cannot be null");
         List<FragmentDefinition> definitions = new ArrayList<>();
-        Matcher matcher = FRAGMENT_PATTERN.matcher(content);
+        StructuredTemplateParser.ParsedTemplate template = templateParser.parse(content);
 
-        while (matcher.find()) {
-            definitions.add(new FragmentDefinition(templatePath, matcher.group(1)));
+        for (StructuredTemplateParser.TemplateElement element : template.elements()) {
+            for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                String name = attribute.name().toLowerCase(Locale.ROOT);
+                if (attribute.hasValue() && FRAGMENT_ATTRIBUTES.contains(name)) {
+                    definitions.add(new FragmentDefinition(templatePath, attribute.value()));
+                }
+            }
         }
 
         return List.copyOf(definitions);

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -2,11 +2,13 @@ package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentDependencyPort;
 import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
@@ -14,10 +16,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 /**
  * フラグメント内で利用している依存コンポーネントを抽出
@@ -27,11 +29,10 @@ public class FragmentDependencyService implements FragmentDependencyPort {
 
     private static final Logger logger = LoggerFactory.getLogger(FragmentDependencyService.class);
 
-    private static final Pattern FRAGMENT_DECL_PATTERN = Pattern.compile(
-        "th:fragment\\s*=\\s*[\"']([^\"']+)[\"']"
-    );
-    private static final Pattern DEPENDENCY_ATTR_PATTERN = Pattern.compile(
-        "th:(?:replace|include|insert)\\s*=\\s*"
+    private static final Set<String> FRAGMENT_ATTRIBUTES = Set.of("th:fragment", "data-th-fragment");
+    private static final Set<String> DEPENDENCY_ATTRIBUTES = Set.of(
+        "th:replace", "th:include", "th:insert",
+        "data-th-replace", "data-th-include", "data-th-insert"
     );
 
     private final ResolvedStorybookConfig storybookConfig;
@@ -40,14 +41,27 @@ public class FragmentDependencyService implements FragmentDependencyPort {
 
     private final ThymeleafletCacheManager cacheManager;
 
+    private final StructuredTemplateParser templateParser;
+
+    @Autowired
     public FragmentDependencyService(
         ResolvedStorybookConfig storybookConfig,
         ResourcePathValidator resourcePathValidator,
         ThymeleafletCacheManager cacheManager
     ) {
+        this(storybookConfig, resourcePathValidator, cacheManager, new StructuredTemplateParser());
+    }
+
+    FragmentDependencyService(
+        ResolvedStorybookConfig storybookConfig,
+        ResourcePathValidator resourcePathValidator,
+        ThymeleafletCacheManager cacheManager,
+        StructuredTemplateParser templateParser
+    ) {
         this.storybookConfig = storybookConfig;
         this.resourcePathValidator = resourcePathValidator;
         this.cacheManager = cacheManager;
+        this.templateParser = templateParser;
     }
 
     public List<DependencyComponent> findDependencies(String templatePath, String fragmentName) {
@@ -67,10 +81,11 @@ public class FragmentDependencyService implements FragmentDependencyPort {
             }
 
             String html = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String target = extractFragmentBlock(html, fragmentName).orElse(html);
+            StructuredTemplateParser.ParsedTemplate template = templateParser.parse(html);
+            List<StructuredTemplateParser.TemplateElement> targetElements = elementsForFragment(template, fragmentName);
 
             Map<String, DependencyComponent> dependencies = new LinkedHashMap<>();
-            for (String expression : extractDependencyExpressions(target)) {
+            for (String expression : extractDependencyExpressions(targetElements)) {
                 Optional<DependencyComponent> component = parseDependency(expression);
                 if (component.isEmpty()) {
                     continue;
@@ -104,11 +119,12 @@ public class FragmentDependencyService implements FragmentDependencyPort {
     }
 
     private Optional<DependencyComponent> parseDependency(String expression) {
-        String[] parts = expression.split("::");
+        String normalizedExpression = unwrapFragmentExpression(expression);
+        String[] parts = normalizedExpression.split("::", 2);
         if (parts.length < 2) {
             return Optional.empty();
         }
-        String templatePath = parts[0].trim();
+        String templatePath = unquote(parts[0].trim());
         String fragmentPart = parts[1].trim();
         String fragmentName = fragmentPart.split("\\(")[0].trim();
 
@@ -120,91 +136,57 @@ public class FragmentDependencyService implements FragmentDependencyPort {
         return Optional.of(new DependencyComponent(templatePath, fragmentName, encodedPath));
     }
 
-    private List<String> extractDependencyExpressions(String html) {
+    private List<String> extractDependencyExpressions(List<StructuredTemplateParser.TemplateElement> elements) {
         List<String> expressions = new ArrayList<>();
-        Matcher matcher = DEPENDENCY_ATTR_PATTERN.matcher(html);
-        while (matcher.find()) {
-            int index = matcher.end();
-            if (index >= html.length()) {
-                continue;
-            }
-            char quote = html.charAt(index);
-            if (quote != '"' && quote != '\'') {
-                continue;
-            }
-            int valueStart = index + 1;
-            int valueEnd = html.indexOf(quote, valueStart);
-            if (valueEnd == -1) {
-                continue;
-            }
-            String rawValue = html.substring(valueStart, valueEnd).trim();
-            if (rawValue.startsWith("~{") && rawValue.endsWith("}")) {
-                expressions.add(rawValue.substring(2, rawValue.length() - 1).trim());
+        for (StructuredTemplateParser.TemplateElement element : elements) {
+            for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                String name = attribute.name().toLowerCase(Locale.ROOT);
+                if (!attribute.hasValue() || !DEPENDENCY_ATTRIBUTES.contains(name)) {
+                    continue;
+                }
+                expressions.add(attribute.value().trim());
             }
         }
         return expressions;
     }
 
-    private Optional<String> extractFragmentBlock(String html, String fragmentName) {
-        Matcher matcher = FRAGMENT_DECL_PATTERN.matcher(html);
-        while (matcher.find()) {
-            String definition = matcher.group(1).trim();
-            String name = definition.split("\\(")[0].trim();
-            if (!name.equals(fragmentName)) {
-                continue;
-            }
-
-            int tagStart = html.lastIndexOf('<', matcher.start());
-            if (tagStart == -1) {
-                return Optional.empty();
-            }
-            int tagEnd = html.indexOf('>', matcher.end());
-            if (tagEnd == -1) {
-                return Optional.empty();
-            }
-
-            Optional<String> tagName = extractTagName(html.substring(tagStart, tagEnd + 1));
-            if (tagName.isEmpty()) {
-                return Optional.empty();
-            }
-            String resolvedTagName = tagName.orElseThrow();
-
-            int depth = 0;
-            int index = tagStart;
-            while (index < html.length()) {
-                int nextOpen = html.indexOf("<" + resolvedTagName, index);
-                int nextClose = html.indexOf("</" + resolvedTagName, index);
-
-                if (nextClose == -1) {
-                    return Optional.of(html.substring(tagStart));
-                }
-
-                if (nextOpen != -1 && nextOpen < nextClose) {
-                    depth++;
-                    index = nextOpen + resolvedTagName.length() + 1;
-                    continue;
-                }
-
-                depth--;
-                int closeEnd = html.indexOf('>', nextClose);
-                if (closeEnd == -1) {
-                    return Optional.of(html.substring(tagStart));
-                }
-                index = closeEnd + 1;
-                if (depth <= 0) {
-                    return Optional.of(html.substring(tagStart, index));
-                }
-            }
-        }
-        return Optional.empty();
+    private List<StructuredTemplateParser.TemplateElement> elementsForFragment(
+        StructuredTemplateParser.ParsedTemplate template,
+        String fragmentName
+    ) {
+        return template.elementsMatchingSubtree(element ->
+            fragmentDefinition(element)
+                .map(definition -> definition.split("\\(", 2)[0].trim())
+                .filter(fragmentName::equals)
+                .isPresent()
+        );
     }
 
-    private Optional<String> extractTagName(String tag) {
-        Matcher matcher = Pattern.compile("<\\s*([a-zA-Z0-9:-]+)").matcher(tag);
-        if (matcher.find()) {
-            return Optional.of(matcher.group(1));
+    private Optional<String> fragmentDefinition(StructuredTemplateParser.TemplateElement element) {
+        return element.attributes().stream()
+            .filter(StructuredTemplateParser.TemplateAttribute::hasValue)
+            .filter(attribute -> FRAGMENT_ATTRIBUTES.contains(attribute.name().toLowerCase(Locale.ROOT)))
+            .map(StructuredTemplateParser.TemplateAttribute::value)
+            .map(String::trim)
+            .findFirst();
+    }
+
+    private String unwrapFragmentExpression(String expression) {
+        String normalized = expression.trim();
+        if (normalized.startsWith("~{") && normalized.endsWith("}")) {
+            return normalized.substring(2, normalized.length() - 1).trim();
         }
-        return Optional.empty();
+        return normalized;
+    }
+
+    private String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+        if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith("\"") && value.endsWith("\""))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     public record DependencyComponent(String templatePath, String fragmentName, String encodedTemplatePath) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
@@ -86,6 +86,32 @@ class StructuredTemplateParserTest {
     }
 
     @Test
+    void parse_shouldExposeSubtreeForNestedElementsWithoutIncludingLaterSiblings() {
+        String html = """
+            <main>
+              <section th:fragment="card">
+                <section>
+                  <span th:text="${view.title}">Title</span>
+                </section>
+              </section>
+              <section th:fragment="other">
+                <span th:text="${view.other}">Other</span>
+              </section>
+            </main>
+            """;
+
+        StructuredTemplateParser.ParsedTemplate parsed = parser.parse(html);
+        StructuredTemplateParser.TemplateElement card = parsed.elements().stream()
+            .filter(element -> element.attributeValue("th:fragment").filter("card"::equals).isPresent())
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(parsed.subtree(card))
+            .extracting(StructuredTemplateParser.TemplateElement::name)
+            .containsExactly("section", "section", "span");
+    }
+
+    @Test
     void parse_shouldExposeTextNodesWithoutTreatingCommentsAsText() {
         String html = """
             <section>

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -186,6 +186,27 @@ class TemplateModelExpressionAnalyzerTest {
     }
 
     @Test
+    void shouldExtractExpressionsWithLiteralBracesAndSelectionExpressions() {
+        String html = """
+            <section>
+              <span th:text="${'}' + view.title}"></span>
+              <span th:title="prefix ${view.subtitle} suffix ${view.count}"></span>
+              <input data-th-value="*{selected.label}" />
+              <span th:text="${view.unclosed"></span>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.modelPaths())
+            .contains(ModelPath.of(List.of("view", "title")))
+            .contains(ModelPath.of(List.of("view", "subtitle")))
+            .contains(ModelPath.of(List.of("view", "count")))
+            .contains(ModelPath.of(List.of("selected", "label")))
+            .doesNotContain(ModelPath.of(List.of("view", "unclosed")));
+    }
+
+    @Test
     void shouldPreserveNoArgAndAliasBehaviorWithTokenizer() {
         String html = """
             <section th:with="current=${view.currentUser}">

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDefinitionParserTest.java
@@ -15,6 +15,9 @@ class FragmentDefinitionParserTest {
         String content = """
             <section th:fragment="card(title, body)">Card</section>
             <footer th:fragment='footer'>Footer</footer>
+            <aside
+                data-th-fragment = "sidebar ( items )"
+            >Sidebar</aside>
             """;
 
         List<FragmentDefinitionParser.FragmentDefinition> definitions = parser.parseTemplate(
@@ -24,10 +27,10 @@ class FragmentDefinitionParserTest {
 
         assertThat(definitions)
             .extracting(FragmentDefinitionParser.FragmentDefinition::definition)
-            .containsExactly("card(title, body)", "footer");
+            .containsExactly("card(title, body)", "footer", "sidebar ( items )");
         assertThat(definitions)
             .extracting(FragmentDefinitionParser.FragmentDefinition::templatePath)
-            .containsExactly("components/card", "components/card");
+            .containsExactly("components/card", "components/card", "components/card");
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
@@ -1,0 +1,88 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResolvedStorybookConfig;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
+import io.github.wamukat.thymeleaflet.infrastructure.configuration.StorybookProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FragmentDependencyServiceTest {
+
+    @Mock
+    private ResourcePathValidator resourcePathValidator;
+
+    @Test
+    void findDependencies_extractsDataThDependenciesInsideTargetFragmentOnly() {
+        String html = """
+            <main>
+              <section data-th-fragment="card(title)">
+                <section>
+                  <span data-th-replace='~{components/title :: heading(text=${title})}'></span>
+                </section>
+                <input data-th-insert="~{components/field :: textField(value=${title})}" />
+              </section>
+              <section th:fragment="other">
+                <span th:replace="~{components/other :: ignored()}"></span>
+              </section>
+            </main>
+            """;
+        FragmentDependencyService service = buildService("pages/card", html);
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/card", "card");
+
+        assertThat(dependencies)
+            .extracting(FragmentDependencyService.DependencyComponent::key)
+            .containsExactly(
+                "components/title::heading",
+                "components/field::textField"
+            );
+    }
+
+    @Test
+    void findDependencies_handlesQuotedTemplatePathsAndDeduplicatesDependencies() {
+        String html = """
+            <article th:fragment="panel">
+              <div th:replace="~{'components/panel-header' :: header()}"></div>
+              <div data-th-include="~{'components/panel-header' :: header()}"></div>
+              <div th:insert="~{components/panel-body :: body()}"></div>
+            </article>
+            """;
+        FragmentDependencyService service = buildService("pages/panel", html);
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/panel", "panel");
+
+        assertThat(dependencies)
+            .extracting(FragmentDependencyService.DependencyComponent::key)
+            .containsExactly(
+                "components/panel-header::header",
+                "components/panel-body::body"
+            );
+    }
+
+    private FragmentDependencyService buildService(String templatePath, String html) {
+        StorybookProperties properties = new StorybookProperties();
+        ResolvedStorybookConfig config = ResolvedStorybookConfig.from(properties, false);
+        ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config);
+        when(resourcePathValidator.findTemplate(eq(templatePath), eq(config.getResources().getTemplatePaths())))
+            .thenReturn(resource(html));
+        return new FragmentDependencyService(config, resourcePathValidator, cacheManager);
+    }
+
+    private ByteArrayResource resource(String html) {
+        return new ByteArrayResource(html.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

Refactor the remaining high-priority template parsing hotspots to use structured parsing instead of regex/string scanning.

## Changes

- Migrate fragment dependency extraction to `StructuredTemplateParser` with target-fragment subtree scoping.
- Migrate fragment definition parsing to structured attribute extraction, including `data-th-fragment`.
- Replace outer `${...}` model-expression extraction regex with quote/brace-aware scanning and `*{...}` support.
- Add regression coverage for `data-th-*` dependencies, quoted template paths, multiple fragments, literal braces, malformed expressions, and subtree boundaries.

## Verification

- `./mvnw -q -Dtest=FragmentDependencyServiceTest,StructuredTemplateParserTest test`
- `./mvnw -q -Dtest=FragmentDefinitionParserTest test`
- `./mvnw -q -Dtest=TemplateModelExpressionAnalyzerTest test`
- `./mvnw test -q`
- `npm run test:e2e:local`
- Sub-agent review: no findings for Kanbalone #486, #487, #488

Closes: N/A
