### PR TITLE
Refactor JavaDoc parsing and release status reporting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,14 +38,27 @@ GPG signing can be configured via environment variables or your local keyring.
 git tag vX.Y.Z
 ```
 
-4) Run the release build:
+4) Run the release build and keep the full deploy log:
 
 ```bash
-./mvnw -Prelease clean deploy
+./mvnw -Prelease clean deploy 2>&1 | tee /tmp/thymeleaflet-release-X.Y.Z.log
 ```
 
-5) Verify that the staging repository is closed and released in Sonatype (auto-release enabled).
-6) Check Maven Central for the published artifacts.
+5) Summarize the Central Publishing deployment status from the log:
+
+```bash
+npm run release:central-status -- /tmp/thymeleaflet-release-X.Y.Z.log
+```
+
+The helper reports:
+
+- `uploaded`: artifacts were uploaded or a deployment ID was created, but validation/publish status was not found.
+- `validated`: Central validation completed, but publish status was not found.
+- `manual-publish-required`: Central accepted/validated the deployment but requires manual publishing. Include the deployment ID and https://central.sonatype.com/publishing/deployments in release notes and do not claim Maven Central publishing is complete.
+- `published`: deployment output indicates the artifacts were published/released.
+
+6) Verify the deployment in Central Portal. If the helper reports `manual-publish-required`, publish the deployment manually from Central Portal or clearly report the remaining manual step.
+7) Check Maven Central for the published artifacts.
 
 ## How To Collect Release Changes (Checklist)
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e:ci": "playwright test --grep-invert \"matches snapshot\"",
     "test:e2e:local:unit": "node --test tests/node/run-local-e2e.test.js",
     "test:workflow": "node --test tests/node/verify-workflow.test.js",
+    "release:central-status": "node scripts/summarize-central-publish.js",
     "test:e2e:local": "node scripts/run-local-e2e.js"
   },
   "devDependencies": {

--- a/scripts/summarize-central-publish.js
+++ b/scripts/summarize-central-publish.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+const CENTRAL_DEPLOYMENTS_URL = 'https://central.sonatype.com/publishing/deployments';
+
+function parseCentralPublishStatus(logText) {
+  const text = String(logText ?? '');
+  const deploymentId = extractDeploymentId(text);
+  const manualPublishRequired = /manual(?:ly)?\s+publish|publish(?:ed)?\s+manual(?:ly)?|manual\s+portal|required.*publish|publish.*required|can\s+be\s+published/i.test(text);
+  const published = !manualPublishRequired && /(?:deployment|artifact|state).*(?:published|released)|(?:published|released).*(?:deployment|artifact|state)|\bPUBLISHED\b|\bRELEASED\b/i.test(text);
+  const validated = /validat(?:ed|ion).*(?:success|passed|complete)|(?:success|passed|complete).*validat(?:ed|ion)|\bVALIDATED\b/i.test(text);
+  const uploaded = /uploaded|created deployment|deployment id|deployment name/i.test(text) || deploymentId !== '';
+
+  return {
+    deploymentId,
+    status: resolveStatus({ manualPublishRequired, published, validated, uploaded }),
+    manualPublishUrl: manualPublishRequired ? CENTRAL_DEPLOYMENTS_URL : '',
+  };
+}
+
+function extractDeploymentId(text) {
+  const labelledMatch = text.match(/deployment(?:\s+(?:id|name))?\s*[:=]\s*([0-9a-f]{8}-[0-9a-f-]{27,})/i);
+  if (labelledMatch) {
+    return labelledMatch[1];
+  }
+  const uuidMatch = text.match(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i);
+  return uuidMatch ? uuidMatch[0] : '';
+}
+
+function resolveStatus({ manualPublishRequired, published, validated, uploaded }) {
+  if (manualPublishRequired) {
+    return 'manual-publish-required';
+  }
+  if (published) {
+    return 'published';
+  }
+  if (validated) {
+    return 'validated';
+  }
+  if (uploaded) {
+    return 'uploaded';
+  }
+  return 'unknown';
+}
+
+function formatCentralPublishStatus(summary) {
+  const lines = [
+    `Maven Central status: ${summary.status}`,
+    `Deployment ID: ${summary.deploymentId || '(not found)'}`,
+  ];
+  if (summary.manualPublishUrl) {
+    lines.push(`Manual publish URL: ${summary.manualPublishUrl}`);
+  }
+  lines.push(`Release note: Maven Central deployment ${summary.deploymentId || '(unknown)'} is ${summary.status}.`);
+  return lines.join('\n');
+}
+
+function readInput(path) {
+  if (path && path !== '-') {
+    return fs.readFileSync(path, 'utf8');
+  }
+  return fs.readFileSync(0, 'utf8');
+}
+
+function main(argv) {
+  const logText = readInput(argv[2]);
+  const summary = parseCentralPublishStatus(logText);
+  process.stdout.write(`${formatCentralPublishStatus(summary)}\n`);
+}
+
+if (require.main === module) {
+  main(process.argv);
+}
+
+module.exports = {
+  CENTRAL_DEPLOYMENTS_URL,
+  parseCentralPublishStatus,
+  formatCentralPublishStatus,
+};

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzer.java
@@ -1,8 +1,6 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -10,58 +8,37 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * HTMLテンプレート内のJavaDocコメント解析Infrastructure実装
- * Legacy実装の完全移設（既存の解析結果との互換性維持を優先）
  */
 @Component
 public class JavaDocAnalyzer {
-    
-    private static final Logger logger = LoggerFactory.getLogger(JavaDocAnalyzer.class);
-    
-    // Legacy実装からの完全コピー
-    private static final Pattern JAVADOC_PATTERN = Pattern.compile(
-        "<!--[^>]*?/\\*\\*([\\s\\S]*?)\\*/[^<]*?-->", 
-        Pattern.MULTILINE | Pattern.DOTALL
-    );
-    
-    private static final Pattern PARAM_PATTERN = Pattern.compile(
-        "@param\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
-        Pattern.MULTILINE | Pattern.DOTALL
-    );
 
-    private static final Pattern MODEL_PATTERN = Pattern.compile(
-        "@model\\s+([\\w.\\[\\]]+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*?)(?=\\s*@param|\\s*@model|\\s*@fragment|\\s*@example|\\s*@background|\\s*\\*/|$)",
-        Pattern.MULTILINE | Pattern.DOTALL
-    );
-
-    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
-        "@fragment\\s+([A-Za-z_][\\w-]*)",
-        Pattern.MULTILINE
-    );
-    
-    private static final Pattern BACKGROUND_PATTERN = Pattern.compile(
-        "@background\\s+(\\S+)",
-        Pattern.MULTILINE
-    );
-    private static final Set<String> EXAMPLE_REPLACE_ATTRIBUTES = Set.of("th:replace", "data-th-replace");
-
-    private final StructuredTemplateParser templateParser;
+    private final JavaDocCommentBlockExtractor commentBlockExtractor;
+    private final JavaDocTagParser tagParser;
+    private final JavaDocExampleParser exampleParser;
 
     public JavaDocAnalyzer() {
         this(new StructuredTemplateParser());
     }
 
     JavaDocAnalyzer(StructuredTemplateParser templateParser) {
-        this.templateParser = templateParser;
+        this(new JavaDocCommentBlockExtractor(), new JavaDocTagParser(), new JavaDocExampleParser(templateParser));
+    }
+
+    JavaDocAnalyzer(
+        JavaDocCommentBlockExtractor commentBlockExtractor,
+        JavaDocTagParser tagParser,
+        JavaDocExampleParser exampleParser
+    ) {
+        this.commentBlockExtractor = Objects.requireNonNull(commentBlockExtractor, "commentBlockExtractor cannot be null");
+        this.tagParser = Objects.requireNonNull(tagParser, "tagParser cannot be null");
+        this.exampleParser = Objects.requireNonNull(exampleParser, "exampleParser cannot be null");
     }
 
     /**
-     * HTMLテンプレートからJavaDocコメントを解析 - Legacy実装移設
+     * HTMLテンプレートからJavaDocコメントを解析
      */
     public List<JavaDocInfo> analyzeJavaDocFromHtml(String htmlContent) {
         Objects.requireNonNull(htmlContent, "htmlContent cannot be null");
@@ -70,309 +47,20 @@ public class JavaDocAnalyzer {
         if (htmlContent.trim().isEmpty()) {
             return docInfoList;
         }
-        
-        Matcher javadocMatcher = JAVADOC_PATTERN.matcher(htmlContent);
-        
-        while (javadocMatcher.find()) {
-            String javadocContent = javadocMatcher.group(1);
-            
-            // 技術的データ抽出処理
-            List<ParameterInfo> parameters = parseParameters(javadocContent);
-            List<ModelInfo> models = parseModels(javadocContent);
-            Optional<String> fragmentName = parseFragmentName(javadocContent);
-            List<ExampleInfo> examples = parseExamples(javadocContent);
-            Optional<String> backgroundColor = parseBackgroundColor(javadocContent);
-            String description = extractDescription(javadocContent);
-            
-            JavaDocInfo docInfo = JavaDocInfo.of(description, parameters, models, fragmentName, examples, backgroundColor);
-            docInfoList.add(docInfo);
+
+        for (String javadocContent : commentBlockExtractor.extract(htmlContent)) {
+            JavaDocTagParser.ParsedTags parsedTags = tagParser.parse(javadocContent);
+            docInfoList.add(JavaDocInfo.of(
+                parsedTags.description(),
+                parsedTags.parameters(),
+                parsedTags.models(),
+                parsedTags.fragmentName(),
+                exampleParser.parse(javadocContent),
+                parsedTags.backgroundColor()
+            ));
         }
-        
+
         return docInfoList;
-    }
-    
-    /**
-     * @paramタグからパラメータ情報を解析
-     */
-    private List<ParameterInfo> parseParameters(String javadocContent) {
-        List<ParameterInfo> parameters = new ArrayList<>();
-        
-        Matcher paramMatcher = PARAM_PATTERN.matcher(javadocContent);
-        while (paramMatcher.find()) {
-            String name = paramMatcher.group(1);
-            String type = paramMatcher.group(2);
-            String requiredOrOptional = paramMatcher.group(3);
-            String fullDescription = paramMatcher.group(4);
-            
-            // デフォルト値の抽出
-            Optional<String> defaultValue = Optional.empty();
-            if (requiredOrOptional.startsWith("optional=")) {
-                String rawDefaultValue = requiredOrOptional.substring("optional=".length());
-                if (!"null".equals(rawDefaultValue)) {
-                    defaultValue = Optional.of(rawDefaultValue);
-                }
-            }
-            
-            boolean required = "required".equals(requiredOrOptional);
-            
-            // 説明文から許可値を分離
-            String description = fullDescription;
-            List<String> allowedValues = Collections.emptyList();
-            
-            // values: "value1", "value2" パターンを検索
-            Pattern valuesPattern = Pattern.compile("。\\s*values:\\s*(.+?)(?=\\s*$)", Pattern.MULTILINE);
-            Matcher valuesMatcher = valuesPattern.matcher(fullDescription);
-            if (valuesMatcher.find()) {
-                String valuesStr = valuesMatcher.group(1);
-                allowedValues = parseAllowedValues(valuesStr);
-                description = fullDescription.replaceAll("。\\s*values:\\s*.+$", "").trim();
-            }
-            
-            description = description.replaceAll("\\s+", " ").trim();
-            
-            parameters.add(ParameterInfo.of(name, type, required, defaultValue, Optional.of(description), allowedValues));
-        }
-        
-        return parameters;
-    }
-
-    /**
-     * @modelタグからモデル情報を解析
-     */
-    private List<ModelInfo> parseModels(String javadocContent) {
-        List<ModelInfo> models = new ArrayList<>();
-
-        Matcher modelMatcher = MODEL_PATTERN.matcher(javadocContent);
-        while (modelMatcher.find()) {
-            String name = modelMatcher.group(1);
-            String type = modelMatcher.group(2);
-            String requiredOrOptional = modelMatcher.group(3);
-            String fullDescription = modelMatcher.group(4);
-
-            Optional<String> defaultValue = Optional.empty();
-            if (requiredOrOptional.startsWith("optional=")) {
-                String rawDefaultValue = requiredOrOptional.substring("optional=".length());
-                if (!"null".equals(rawDefaultValue)) {
-                    defaultValue = Optional.of(rawDefaultValue);
-                }
-            }
-
-            boolean required = "required".equals(requiredOrOptional);
-            String description = fullDescription.replaceAll("\\s+", " ").trim();
-
-            models.add(ModelInfo.of(name, type, required, defaultValue, Optional.of(description)));
-        }
-
-        return models;
-    }
-    
-    private List<String> parseAllowedValues(String valuesStr) {
-        if (valuesStr.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-        
-        List<String> values = new ArrayList<>();
-        Pattern valuePattern = Pattern.compile("\"([^\"]+)\"");
-        Matcher valueMatcher = valuePattern.matcher(valuesStr);
-        while (valueMatcher.find()) {
-            values.add(valueMatcher.group(1));
-        }
-        
-        return values;
-    }
-    
-    /**
-     * @fragmentタグから明示的なフラグメント名を解析
-     */
-    private Optional<String> parseFragmentName(String javadocContent) {
-        Matcher fragmentMatcher = FRAGMENT_PATTERN.matcher(javadocContent);
-        if (fragmentMatcher.find()) {
-            return Optional.of(fragmentMatcher.group(1));
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * @exampleタグから使用例を解析
-     */
-    private List<ExampleInfo> parseExamples(String javadocContent) {
-        List<ExampleInfo> examples = new ArrayList<>();
-
-        for (String exampleMarkup : extractExampleMarkup(javadocContent)) {
-            StructuredTemplateParser.ParsedTemplate parsedTemplate = parseExampleMarkup(exampleMarkup);
-            for (StructuredTemplateParser.TemplateElement element : parsedTemplate.elements()) {
-                for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
-                    String normalizedName = attribute.name().toLowerCase(java.util.Locale.ROOT);
-                    if (!attribute.hasValue() || !EXAMPLE_REPLACE_ATTRIBUTES.contains(normalizedName)) {
-                        continue;
-                    }
-                    parseExampleReference(attribute.value()).ifPresent(examples::add);
-                }
-            }
-        }
-        return examples;
-    }
-
-    private List<String> extractExampleMarkup(String javadocContent) {
-        List<String> examples = new ArrayList<>();
-        StringBuilder currentExample = new StringBuilder();
-        boolean collectingExample = false;
-        String[] lines = javadocContent.split("\n");
-        for (String rawLine : lines) {
-            String line = rawLine.trim();
-            if (line.startsWith("*")) {
-                line = line.substring(1).trim();
-            }
-
-            if (line.startsWith("@example")) {
-                addExampleIfPresent(examples, currentExample);
-                currentExample.setLength(0);
-                collectingExample = true;
-                String exampleBody = line.substring("@example".length()).trim();
-                appendMarkupLine(currentExample, exampleBody);
-                continue;
-            }
-
-            if (!collectingExample) {
-                continue;
-            }
-            if (line.startsWith("@")) {
-                addExampleIfPresent(examples, currentExample);
-                currentExample.setLength(0);
-                collectingExample = false;
-                continue;
-            }
-            appendMarkupLine(currentExample, line);
-        }
-        addExampleIfPresent(examples, currentExample);
-        return examples;
-    }
-
-    private void appendMarkupLine(StringBuilder exampleMarkup, String line) {
-        if (line.isBlank()) {
-            return;
-        }
-        if (exampleMarkup.isEmpty()) {
-            int markupStart = line.indexOf('<');
-            if (markupStart < 0) {
-                return;
-            }
-            exampleMarkup.append(line.substring(markupStart));
-            return;
-        }
-        exampleMarkup.append('\n').append(line);
-    }
-
-    private void addExampleIfPresent(List<String> examples, StringBuilder exampleMarkup) {
-        if (!exampleMarkup.isEmpty()) {
-            examples.add(exampleMarkup.toString());
-        }
-    }
-
-    private StructuredTemplateParser.ParsedTemplate parseExampleMarkup(String exampleMarkup) {
-        try {
-            return templateParser.parse(exampleMarkup);
-        } catch (IllegalArgumentException parseFailure) {
-            logger.debug("Failed to parse @example markup: {}", exampleMarkup, parseFailure);
-            return new StructuredTemplateParser.ParsedTemplate(List.of(), List.of(), List.of());
-        }
-    }
-
-    private Optional<ExampleInfo> parseExampleReference(String rawReference) {
-        String expression = rawReference.trim();
-        if (expression.startsWith("~{") && expression.endsWith("}")) {
-            expression = expression.substring(2, expression.length() - 1).trim();
-        }
-        int fragmentSeparator = expression.indexOf("::");
-        if (fragmentSeparator <= 0) {
-            return Optional.empty();
-        }
-        String templatePath = unquote(expression.substring(0, fragmentSeparator).trim());
-        String fragmentExpression = expression.substring(fragmentSeparator + 2).trim();
-        if (templatePath.isBlank() || fragmentExpression.isBlank()) {
-            return Optional.empty();
-        }
-        String fragmentName = fragmentExpression;
-        String argumentsStr = "";
-        int openParen = fragmentExpression.indexOf('(');
-        if (openParen >= 0) {
-            int closeParen = fragmentExpression.lastIndexOf(')');
-            if (closeParen < openParen) {
-                return Optional.empty();
-            }
-            fragmentName = fragmentExpression.substring(0, openParen).trim();
-            argumentsStr = fragmentExpression.substring(openParen + 1, closeParen).trim();
-        }
-        if (fragmentName.isBlank()) {
-            return Optional.empty();
-        }
-        return Optional.of(ExampleInfo.of(templatePath, fragmentName, parseArguments(argumentsStr)));
-    }
-
-    private String unquote(String value) {
-        String trimmed = value.trim();
-        if (trimmed.length() >= 2
-            && ((trimmed.startsWith("'") && trimmed.endsWith("'"))
-            || (trimmed.startsWith("\"") && trimmed.endsWith("\"")))) {
-            return trimmed.substring(1, trimmed.length() - 1);
-        }
-        return trimmed;
-    }
-    
-    /**
-     * @backgroundタグから背景色を解析
-     */
-    private Optional<String> parseBackgroundColor(String javadocContent) {
-        Matcher backgroundMatcher = BACKGROUND_PATTERN.matcher(javadocContent);
-        if (backgroundMatcher.find()) {
-            return Optional.of(backgroundMatcher.group(1));
-        }
-        return Optional.empty();
-    }
-    
-    /**
-     * 引数文字列をパース
-     */
-    private List<String> parseArguments(String argumentsStr) {
-        if (argumentsStr.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-        
-        List<String> arguments = new ArrayList<>();
-        String[] parts = argumentsStr.split(",(?=(?:[^']*'[^']*')*[^']*$)");
-        for (String part : parts) {
-            arguments.add(part.trim());
-        }
-        
-        return arguments;
-    }
-    
-    /**
-     * 説明文を抽出
-     */
-    private String extractDescription(String javadocContent) {
-        String[] lines = javadocContent.split("\n");
-        StringBuilder description = new StringBuilder();
-        
-        for (String line : lines) {
-            line = line.trim();
-            if (line.startsWith("*")) {
-                line = line.substring(1).trim();
-            }
-            
-            if (line.startsWith("@")) {
-                break;
-            }
-            
-            if (!line.isEmpty()) {
-                if (description.length() > 0) {
-                    description.append("\n");
-                }
-                description.append(line);
-            }
-        }
-        
-        return description.toString();
     }
     
     /**

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocCommentBlockExtractor.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocCommentBlockExtractor.java
@@ -1,0 +1,23 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class JavaDocCommentBlockExtractor {
+
+    private static final Pattern JAVADOC_PATTERN = Pattern.compile(
+        "<!--[^>]*?/\\*\\*([\\s\\S]*?)\\*/[^<]*?-->",
+        Pattern.MULTILINE | Pattern.DOTALL
+    );
+
+    List<String> extract(String htmlContent) {
+        List<String> blocks = new ArrayList<>();
+        Matcher javadocMatcher = JAVADOC_PATTERN.matcher(htmlContent);
+        while (javadocMatcher.find()) {
+            blocks.add(javadocMatcher.group(1));
+        }
+        return blocks;
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
@@ -1,0 +1,167 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+final class JavaDocExampleParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(JavaDocExampleParser.class);
+    private static final Set<String> EXAMPLE_REPLACE_ATTRIBUTES = Set.of("th:replace", "data-th-replace");
+
+    private final StructuredTemplateParser templateParser;
+
+    JavaDocExampleParser(StructuredTemplateParser templateParser) {
+        this.templateParser = Objects.requireNonNull(templateParser, "templateParser cannot be null");
+    }
+
+    List<JavaDocAnalyzer.ExampleInfo> parse(String javadocContent) {
+        List<JavaDocAnalyzer.ExampleInfo> examples = new ArrayList<>();
+
+        for (String exampleMarkup : extractExampleMarkup(javadocContent)) {
+            StructuredTemplateParser.ParsedTemplate parsedTemplate = parseExampleMarkup(exampleMarkup);
+            for (StructuredTemplateParser.TemplateElement element : parsedTemplate.elements()) {
+                for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                    String normalizedName = attribute.name().toLowerCase(java.util.Locale.ROOT);
+                    if (!attribute.hasValue() || !EXAMPLE_REPLACE_ATTRIBUTES.contains(normalizedName)) {
+                        continue;
+                    }
+                    parseExampleReference(attribute.value()).ifPresent(examples::add);
+                }
+            }
+        }
+        return examples;
+    }
+
+    private List<String> extractExampleMarkup(String javadocContent) {
+        List<String> examples = new ArrayList<>();
+        StringBuilder currentExample = new StringBuilder();
+        boolean collectingExample = false;
+        String[] lines = javadocContent.split("\n");
+        for (String rawLine : lines) {
+            String line = normalizeJavadocLine(rawLine);
+
+            if (line.startsWith("@example")) {
+                addExampleIfPresent(examples, currentExample);
+                currentExample.setLength(0);
+                collectingExample = true;
+                String exampleBody = line.substring("@example".length()).trim();
+                appendMarkupLine(currentExample, exampleBody);
+                continue;
+            }
+
+            if (!collectingExample) {
+                continue;
+            }
+            if (line.startsWith("@")) {
+                addExampleIfPresent(examples, currentExample);
+                currentExample.setLength(0);
+                collectingExample = false;
+                continue;
+            }
+            appendMarkupLine(currentExample, line);
+        }
+        addExampleIfPresent(examples, currentExample);
+        return examples;
+    }
+
+    private String normalizeJavadocLine(String rawLine) {
+        String line = rawLine.trim();
+        if (line.startsWith("*")) {
+            return line.substring(1).trim();
+        }
+        return line;
+    }
+
+    private void appendMarkupLine(StringBuilder exampleMarkup, String line) {
+        if (line.isBlank()) {
+            return;
+        }
+        if (exampleMarkup.isEmpty()) {
+            int markupStart = line.indexOf('<');
+            if (markupStart < 0) {
+                return;
+            }
+            exampleMarkup.append(line.substring(markupStart));
+            return;
+        }
+        exampleMarkup.append('\n').append(line);
+    }
+
+    private void addExampleIfPresent(List<String> examples, StringBuilder exampleMarkup) {
+        if (!exampleMarkup.isEmpty()) {
+            examples.add(exampleMarkup.toString());
+        }
+    }
+
+    private StructuredTemplateParser.ParsedTemplate parseExampleMarkup(String exampleMarkup) {
+        try {
+            return templateParser.parse(exampleMarkup);
+        } catch (IllegalArgumentException parseFailure) {
+            logger.debug("Failed to parse @example markup: {}", exampleMarkup, parseFailure);
+            return new StructuredTemplateParser.ParsedTemplate(List.of(), List.of(), List.of());
+        }
+    }
+
+    private Optional<JavaDocAnalyzer.ExampleInfo> parseExampleReference(String rawReference) {
+        String expression = rawReference.trim();
+        if (expression.startsWith("~{") && expression.endsWith("}")) {
+            expression = expression.substring(2, expression.length() - 1).trim();
+        }
+        int fragmentSeparator = expression.indexOf("::");
+        if (fragmentSeparator <= 0) {
+            return Optional.empty();
+        }
+        String templatePath = unquote(expression.substring(0, fragmentSeparator).trim());
+        String fragmentExpression = expression.substring(fragmentSeparator + 2).trim();
+        if (templatePath.isBlank() || fragmentExpression.isBlank()) {
+            return Optional.empty();
+        }
+        String fragmentName = fragmentExpression;
+        String argumentsStr = "";
+        int openParen = fragmentExpression.indexOf('(');
+        if (openParen >= 0) {
+            int closeParen = fragmentExpression.lastIndexOf(')');
+            if (closeParen < openParen) {
+                return Optional.empty();
+            }
+            fragmentName = fragmentExpression.substring(0, openParen).trim();
+            argumentsStr = fragmentExpression.substring(openParen + 1, closeParen).trim();
+        }
+        if (fragmentName.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(JavaDocAnalyzer.ExampleInfo.of(templatePath, fragmentName, parseArguments(argumentsStr)));
+    }
+
+    private String unquote(String value) {
+        String trimmed = value.trim();
+        if (trimmed.length() >= 2
+            && ((trimmed.startsWith("'") && trimmed.endsWith("'"))
+            || (trimmed.startsWith("\"") && trimmed.endsWith("\"")))) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    private List<String> parseArguments(String argumentsStr) {
+        if (argumentsStr.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> arguments = new ArrayList<>();
+        String[] parts = argumentsStr.split(",(?=(?:[^']*'[^']*')*[^']*$)");
+        for (String part : parts) {
+            arguments.add(part.trim());
+        }
+
+        return arguments;
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParser.java
@@ -1,0 +1,237 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class JavaDocTagParser {
+
+    private static final Pattern PARAM_PATTERN = Pattern.compile(
+        "@param\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*)",
+        Pattern.DOTALL
+    );
+
+    private static final Pattern MODEL_PATTERN = Pattern.compile(
+        "@model\\s+([\\w.\\[\\]]+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*)",
+        Pattern.DOTALL
+    );
+
+    private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
+        "@fragment\\s+([A-Za-z_][\\w-]*)",
+        Pattern.MULTILINE
+    );
+
+    private static final Pattern BACKGROUND_PATTERN = Pattern.compile(
+        "@background\\s+(\\S+)",
+        Pattern.MULTILINE
+    );
+
+    private static final Pattern VALUES_PATTERN = Pattern.compile(
+        "[。.]?\\s*values:\\s*(.+?)(?=\\s*$)",
+        Pattern.MULTILINE
+    );
+
+    private static final Pattern VALUE_PATTERN = Pattern.compile("\"([^\"]+)\"");
+
+    ParsedTags parse(String javadocContent) {
+        List<String> lines = normalizeJavadocLines(javadocContent);
+        List<String> tagBlocks = collectTagBlocks(lines);
+        return new ParsedTags(
+            extractDescription(lines),
+            parseParameters(tagBlocks),
+            parseModels(tagBlocks),
+            parseFragmentName(tagBlocks),
+            parseBackgroundColor(tagBlocks)
+        );
+    }
+
+    private List<JavaDocAnalyzer.ParameterInfo> parseParameters(List<String> tagBlocks) {
+        List<JavaDocAnalyzer.ParameterInfo> parameters = new ArrayList<>();
+
+        for (String tagBlock : tagBlocks) {
+            Matcher paramMatcher = PARAM_PATTERN.matcher(tagBlock);
+            if (!paramMatcher.matches()) {
+                continue;
+            }
+            String name = paramMatcher.group(1);
+            String type = paramMatcher.group(2);
+            String requiredOrOptional = paramMatcher.group(3);
+            ParsedDescription parsedDescription = parseDescriptionWithAllowedValues(paramMatcher.group(4));
+
+            parameters.add(JavaDocAnalyzer.ParameterInfo.of(
+                name,
+                type,
+                "required".equals(requiredOrOptional),
+                parseDefaultValue(requiredOrOptional),
+                Optional.of(parsedDescription.description()),
+                parsedDescription.allowedValues()
+            ));
+        }
+
+        return parameters;
+    }
+
+    private List<JavaDocAnalyzer.ModelInfo> parseModels(List<String> tagBlocks) {
+        List<JavaDocAnalyzer.ModelInfo> models = new ArrayList<>();
+
+        for (String tagBlock : tagBlocks) {
+            Matcher modelMatcher = MODEL_PATTERN.matcher(tagBlock);
+            if (!modelMatcher.matches()) {
+                continue;
+            }
+            String name = modelMatcher.group(1);
+            String type = modelMatcher.group(2);
+            String requiredOrOptional = modelMatcher.group(3);
+            String description = normalizeDescription(modelMatcher.group(4));
+
+            models.add(JavaDocAnalyzer.ModelInfo.of(
+                name,
+                type,
+                "required".equals(requiredOrOptional),
+                parseDefaultValue(requiredOrOptional),
+                Optional.of(description)
+            ));
+        }
+
+        return models;
+    }
+
+    private Optional<String> parseDefaultValue(String requiredOrOptional) {
+        if (!requiredOrOptional.startsWith("optional=")) {
+            return Optional.empty();
+        }
+        String rawDefaultValue = requiredOrOptional.substring("optional=".length());
+        if ("null".equals(rawDefaultValue)) {
+            return Optional.empty();
+        }
+        return Optional.of(rawDefaultValue);
+    }
+
+    private ParsedDescription parseDescriptionWithAllowedValues(String fullDescription) {
+        Matcher valuesMatcher = VALUES_PATTERN.matcher(fullDescription);
+        if (!valuesMatcher.find()) {
+            return new ParsedDescription(normalizeDescription(fullDescription), Collections.emptyList());
+        }
+
+        String valuesStr = valuesMatcher.group(1);
+        String description = fullDescription.substring(0, valuesMatcher.start()).trim();
+        return new ParsedDescription(normalizeDescription(description), parseAllowedValues(valuesStr));
+    }
+
+    private List<String> parseAllowedValues(String valuesStr) {
+        if (valuesStr.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> values = new ArrayList<>();
+        Matcher valueMatcher = VALUE_PATTERN.matcher(valuesStr);
+        while (valueMatcher.find()) {
+            values.add(valueMatcher.group(1));
+        }
+
+        return values;
+    }
+
+    private Optional<String> parseFragmentName(List<String> tagBlocks) {
+        for (String tagBlock : tagBlocks) {
+            Matcher fragmentMatcher = FRAGMENT_PATTERN.matcher(tagBlock);
+            if (fragmentMatcher.find()) {
+                return Optional.of(fragmentMatcher.group(1));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> parseBackgroundColor(List<String> tagBlocks) {
+        for (String tagBlock : tagBlocks) {
+            Matcher backgroundMatcher = BACKGROUND_PATTERN.matcher(tagBlock);
+            if (backgroundMatcher.find()) {
+                return Optional.of(backgroundMatcher.group(1));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String extractDescription(List<String> lines) {
+        StringBuilder description = new StringBuilder();
+
+        for (String line : lines) {
+            if (line.startsWith("@")) {
+                break;
+            }
+
+            if (!line.isEmpty()) {
+                if (!description.isEmpty()) {
+                    description.append("\n");
+                }
+                description.append(line);
+            }
+        }
+
+        return description.toString();
+    }
+
+    private List<String> collectTagBlocks(List<String> lines) {
+        List<String> tagBlocks = new ArrayList<>();
+        StringBuilder currentTag = new StringBuilder();
+        boolean collectingTag = false;
+
+        for (String line : lines) {
+            if (line.startsWith("@")) {
+                addTagBlockIfPresent(tagBlocks, currentTag);
+                currentTag.setLength(0);
+                currentTag.append(line);
+                collectingTag = true;
+                continue;
+            }
+            if (!collectingTag || line.isBlank()) {
+                continue;
+            }
+            currentTag.append('\n').append(line);
+        }
+
+        addTagBlockIfPresent(tagBlocks, currentTag);
+        return tagBlocks;
+    }
+
+    private void addTagBlockIfPresent(List<String> tagBlocks, StringBuilder currentTag) {
+        if (!currentTag.isEmpty()) {
+            tagBlocks.add(currentTag.toString());
+        }
+    }
+
+    private List<String> normalizeJavadocLines(String javadocContent) {
+        List<String> lines = new ArrayList<>();
+        for (String rawLine : javadocContent.split("\n")) {
+            lines.add(normalizeJavadocLine(rawLine));
+        }
+        return lines;
+    }
+
+    private String normalizeJavadocLine(String rawLine) {
+        String line = rawLine.trim();
+        if (line.startsWith("*")) {
+            return line.substring(1).trim();
+        }
+        return line;
+    }
+
+    private String normalizeDescription(String description) {
+        return description.replaceAll("\\s+", " ").trim();
+    }
+
+    record ParsedTags(
+        String description,
+        List<JavaDocAnalyzer.ParameterInfo> parameters,
+        List<JavaDocAnalyzer.ModelInfo> models,
+        Optional<String> fragmentName,
+        Optional<String> backgroundColor
+    ) {
+    }
+
+    private record ParsedDescription(String description, List<String> allowedValues) {
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
@@ -387,4 +387,89 @@ class JavaDocAnalyzerTest {
         assertThat(examples.getFirst().getFragmentName()).isEqualTo("statusBadge");
         assertThat(examples.getFirst().getArguments()).containsExactly("label='Ready > Draft'");
     }
+
+    @Test
+    @DisplayName("複数コメントで複数行説明・許可値・デフォルト値・背景色を維持して解析できる")
+    void shouldParseMultipleBlocksWithMultilineDescriptionsAllowedValuesDefaultsAndBackground() {
+        // Given
+        String htmlContent = """
+            <main>
+            <!--
+            /**
+             * Account status badge.
+             * Renders a compact label for dashboard tables.
+             *
+             * @fragment accountStatus
+             * @param status {@code String} [required] Account status label.
+             * Supports active and suspended states。 values: "active", "suspended"
+             * @param muted {@code Boolean} [optional=false] Render muted color.
+             * @model account.id {@code String} [required] Account identifier
+             * @example <div th:replace="~{accounts/status :: accountStatus('active', false)}"></div>
+             * @background #f8fafc
+             */
+            -->
+            <div th:fragment="accountStatus(status, muted)">Status</div>
+
+            <!--
+            /**
+             * Account summary card.
+             *
+             * @param title {@code String} [optional=Summary] Card title
+             * @example <th:block data-th-replace="~{'accounts/card' :: accountCard(title='Summary')}"></th:block>
+             */
+            -->
+            <section th:fragment="accountCard(title)">Card</section>
+            </main>
+            """;
+
+        // When
+        List<JavaDocAnalyzer.JavaDocInfo> result = analyzer.analyzeJavaDocFromHtml(htmlContent);
+
+        // Then
+        assertThat(result).hasSize(2);
+
+        JavaDocAnalyzer.JavaDocInfo statusDoc = result.get(0);
+        assertThat(statusDoc.getDescription())
+            .isEqualTo("Account status badge.\nRenders a compact label for dashboard tables.");
+        assertThat(statusDoc.getFragmentNameOptional()).contains("accountStatus");
+        assertThat(statusDoc.getBackgroundColorOptional()).contains("#f8fafc");
+        assertThat(statusDoc.getModels()).singleElement()
+            .satisfies(model -> {
+                assertThat(model.getName()).isEqualTo("account.id");
+                assertThat(model.isRequired()).isTrue();
+            });
+        assertThat(statusDoc.getParameters()).hasSize(2);
+        assertThat(statusDoc.getParameters().get(0))
+            .satisfies(parameter -> {
+                assertThat(parameter.getName()).isEqualTo("status");
+                assertThat(parameter.isRequired()).isTrue();
+                assertThat(parameter.getDescription()).isEqualTo("Account status label. Supports active and suspended states");
+                assertThat(parameter.getAllowedValues()).containsExactly("active", "suspended");
+            });
+        assertThat(statusDoc.getParameters().get(1))
+            .satisfies(parameter -> {
+                assertThat(parameter.getName()).isEqualTo("muted");
+                assertThat(parameter.isRequired()).isFalse();
+                assertThat(parameter.getDefaultValueOptional()).contains("false");
+            });
+        assertThat(statusDoc.getExamples()).singleElement()
+            .satisfies(example -> {
+                assertThat(example.getTemplatePath()).isEqualTo("accounts/status");
+                assertThat(example.getFragmentName()).isEqualTo("accountStatus");
+                assertThat(example.getArguments()).containsExactly("'active'", "false");
+            });
+
+        JavaDocAnalyzer.JavaDocInfo cardDoc = result.get(1);
+        assertThat(cardDoc.getParameters()).singleElement()
+            .satisfies(parameter -> {
+                assertThat(parameter.getName()).isEqualTo("title");
+                assertThat(parameter.getDefaultValueOptional()).contains("Summary");
+            });
+        assertThat(cardDoc.getExamples()).singleElement()
+            .satisfies(example -> {
+                assertThat(example.getTemplatePath()).isEqualTo("accounts/card");
+                assertThat(example.getFragmentName()).isEqualTo("accountCard");
+                assertThat(example.getArguments()).containsExactly("title='Summary'");
+            });
+    }
 }

--- a/tests/node/summarize-central-publish.test.js
+++ b/tests/node/summarize-central-publish.test.js
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  CENTRAL_DEPLOYMENTS_URL,
+  formatCentralPublishStatus,
+  parseCentralPublishStatus,
+} = require('../../scripts/summarize-central-publish');
+
+test('parseCentralPublishStatus reports manual publish required with deployment id and URL', () => {
+  const summary = parseCentralPublishStatus(`
+    [INFO] Deployment ID: 4cc8f928-65c6-47d0-983b-24a451f11453
+    [INFO] Deployment validated successfully.
+    [INFO] This deployment requires manual publish in Central Portal.
+  `);
+
+  assert.deepEqual(summary, {
+    deploymentId: '4cc8f928-65c6-47d0-983b-24a451f11453',
+    status: 'manual-publish-required',
+    manualPublishUrl: CENTRAL_DEPLOYMENTS_URL,
+  });
+});
+
+test('parseCentralPublishStatus distinguishes uploaded, validated, and published states', () => {
+  assert.equal(parseCentralPublishStatus('Created deployment id: 11111111-1111-1111-1111-111111111111').status, 'uploaded');
+  assert.equal(parseCentralPublishStatus('Deployment validation passed for 22222222-2222-2222-2222-222222222222').status, 'validated');
+  assert.equal(parseCentralPublishStatus('Deployment artifact published for 33333333-3333-3333-3333-333333333333').status, 'published');
+});
+
+test('parseCentralPublishStatus handles Central state-token wording', () => {
+  assert.equal(
+    parseCentralPublishStatus('Deployment 44444444-4444-4444-4444-444444444444 has been VALIDATED').status,
+    'validated',
+  );
+  assert.equal(
+    parseCentralPublishStatus('Deployment 55555555-5555-5555-5555-555555555555 state: PUBLISHED').status,
+    'published',
+  );
+});
+
+test('parseCentralPublishStatus does not treat manual publish guidance as already published', () => {
+  const summary = parseCentralPublishStatus(
+    'Deployment 66666666-6666-6666-6666-666666666666 can be published manually in the Central Portal',
+  );
+
+  assert.equal(summary.status, 'manual-publish-required');
+  assert.equal(summary.manualPublishUrl, CENTRAL_DEPLOYMENTS_URL);
+});
+
+test('formatCentralPublishStatus creates a release-note-ready summary', () => {
+  const output = formatCentralPublishStatus({
+    deploymentId: '4cc8f928-65c6-47d0-983b-24a451f11453',
+    status: 'manual-publish-required',
+    manualPublishUrl: CENTRAL_DEPLOYMENTS_URL,
+  });
+
+  assert.match(output, /Maven Central status: manual-publish-required/);
+  assert.match(output, /Deployment ID: 4cc8f928-65c6-47d0-983b-24a451f11453/);
+  assert.match(output, /Manual publish URL: https:\/\/central\.sonatype\.com\/publishing\/deployments/);
+  assert.match(output, /Release note: Maven Central deployment 4cc8f928-65c6-47d0-983b-24a451f11453 is manual-publish-required\./);
+});


### PR DESCRIPTION
## Summary

- Split JavaDocAnalyzer parsing into focused comment-block, tag, and example parser collaborators.
- Added JavaDoc regression coverage for multiline descriptions, allowed values, defaults, examples, background color, models, fragments, and multiple doc blocks.
- Added a Central Publishing release-log helper plus RELEASE.md guidance for uploaded, validated, manual-publish-required, and published statuses.

## Verification

- `./mvnw -q -Dtest=JavaDocAnalyzerTest test`
- `node --test tests/node/summarize-central-publish.test.js`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

Closes: N/A
