### PR TITLE
Fix Central deployment id extraction

### DIFF
--- a/scripts/summarize-central-publish.js
+++ b/scripts/summarize-central-publish.js
@@ -20,9 +20,13 @@ function parseCentralPublishStatus(logText) {
 }
 
 function extractDeploymentId(text) {
-  const labelledMatch = text.match(/deployment(?:\s+(?:id|name))?\s*[:=]\s*([0-9a-f]{8}-[0-9a-f-]{27,})/i);
+  const labelledMatch = text.match(/\bdeployment(?:\s*id|\s+id)?\s*[:=]\s*([0-9a-f]{8}-[0-9a-f-]{27,})/i);
   if (labelledMatch) {
     return labelledMatch[1];
+  }
+  const deploymentLineMatch = text.match(/\bDeployment\s+([0-9a-f]{8}-[0-9a-f-]{27,})\b/i);
+  if (deploymentLineMatch) {
+    return deploymentLineMatch[1];
   }
   const uuidMatch = text.match(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i);
   return uuidMatch ? uuidMatch[0] : '';

--- a/tests/fixtures/central-publishing/noisy-manual-publish.txt
+++ b/tests/fixtures/central-publishing/noisy-manual-publish.txt
@@ -1,0 +1,11 @@
+[INFO] Running io.github.wamukat.thymeleaflet.contract.FragmentPreviewContractTest
+2026-05-02T11:57:09.469+09:00  WARN 76554 --- [           main] .s.s.UserDetailsServiceAutoConfiguration :
+
+Using generated security password: e3ac34f3-c5a3-41d8-a969-d702d21a0209
+
+This generated password is for development use only.
+[INFO] Uploaded bundle successfully, deployment name: Deployment, deploymentId: 3ab9d8d4-9a62-4835-8751-c7766d3ce6b8. Deployment will require manual publishing
+[INFO] Waiting until Deployment 3ab9d8d4-9a62-4835-8751-c7766d3ce6b8 is validated
+[INFO] Deployment 3ab9d8d4-9a62-4835-8751-c7766d3ce6b8 has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS

--- a/tests/node/summarize-central-publish.test.js
+++ b/tests/node/summarize-central-publish.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const test = require('node:test');
 
 const {
@@ -16,6 +17,18 @@ test('parseCentralPublishStatus reports manual publish required with deployment 
 
   assert.deepEqual(summary, {
     deploymentId: '4cc8f928-65c6-47d0-983b-24a451f11453',
+    status: 'manual-publish-required',
+    manualPublishUrl: CENTRAL_DEPLOYMENTS_URL,
+  });
+});
+
+test('parseCentralPublishStatus prefers Central deploymentId over unrelated UUIDs in noisy logs', () => {
+  const log = fs.readFileSync('tests/fixtures/central-publishing/noisy-manual-publish.txt', 'utf8');
+
+  const summary = parseCentralPublishStatus(log);
+
+  assert.deepEqual(summary, {
+    deploymentId: '3ab9d8d4-9a62-4835-8751-c7766d3ce6b8',
     status: 'manual-publish-required',
     manualPublishUrl: CENTRAL_DEPLOYMENTS_URL,
   });


### PR DESCRIPTION
## Summary
- Fix Central Publishing deployment ID extraction so labelled `deploymentId:` is preferred over unrelated UUIDs in noisy Maven/Spring logs.
- Add a noisy release-log fixture covering Spring generated password UUIDs before the Central deployment line.

## Verification
- `node --test tests/node/summarize-central-publish.test.js`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local`
- `git diff --check`

## Tracking
Kanban: #497
Closes: N/A
