### PR TITLE
Expand parser fixture corpus

### DIFF
--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.domain.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.wamukat.thymeleaflet.testsupport.FixtureResources;
 import org.junit.jupiter.api.Test;
 
 class StructuredTemplateParserTest {
@@ -130,5 +131,43 @@ class StructuredTemplateParserTest {
             .extracting(StructuredTemplateParser.TemplateComment::content)
             .asString()
             .contains("commented.out");
+    }
+
+    @Test
+    void parse_shouldCoverRealRegressionCorpusFixtures() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        StructuredTemplateParser.ParsedTemplate parsed = parser.parse(html);
+
+        assertThat(fragmentDefinitions(parsed))
+            .contains(
+                "dataThList",
+                "quotedSelectorShell",
+                "quotedTarget(label)",
+                "noArgReferenceShell",
+                "noArgReferenceTarget",
+                "nestedFragmentShell",
+                "nestedChild(title)",
+                "malformedHtmlShell"
+            );
+        assertThat(parsed.elements())
+            .anySatisfy(element -> assertThat(element.attributeValue("data-th-each"))
+                .hasValue("item : ${view.items}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("th:replace"))
+                .hasValue("~{'regression/parser-corpus' :: quotedTarget(label=${view.label})}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("th:replace"))
+                .hasValue("~{regression/parser-corpus :: noArgReferenceTarget()}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("data-th-text"))
+                .hasValue("${view.malformed.label}"));
+        assertThat(parsed.comments())
+            .extracting(StructuredTemplateParser.TemplateComment::content)
+            .anySatisfy(comment -> assertThat(comment).contains("GH-149-style"))
+            .anySatisfy(comment -> assertThat(comment).contains("malformed-but-browser-tolerated HTML"));
+    }
+
+    private static java.util.List<String> fragmentDefinitions(StructuredTemplateParser.ParsedTemplate parsed) {
+        return parsed.elements().stream()
+            .flatMap(element -> element.attributeValue("th:fragment").stream())
+            .toList();
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.domain.service;
 
 import io.github.wamukat.thymeleaflet.domain.model.ModelPath;
 import io.github.wamukat.thymeleaflet.domain.model.TemplateInference;
+import io.github.wamukat.thymeleaflet.testsupport.FixtureResources;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -248,5 +249,23 @@ class TemplateModelExpressionAnalyzerTest {
             .doesNotContain(ModelPath.of(List.of("key")))
             .doesNotContain(ModelPath.of(List.of("view", "map", "label")))
             .doesNotContain(ModelPath.of(List.of("view", "items", "name")));
+    }
+
+    @Test
+    void shouldAnalyzeRealRegressionCorpusFixture() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.modelPaths())
+            .contains(ModelPath.of(List.of("view", "items")))
+            .contains(ModelPath.of(List.of("item", "label")))
+            .contains(ModelPath.of(List.of("view", "label")))
+            .contains(ModelPath.of(List.of("view", "nested", "title")))
+            .contains(ModelPath.of(List.of("view", "malformed", "label")));
+        assertThat(snapshot.loopVariablePaths())
+            .containsEntry("item", ModelPath.of(List.of("view", "items")));
+        assertThat(snapshot.referencedTemplatePathsWithRecursionFlags())
+            .containsEntry("regression/parser-corpus", true);
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
@@ -184,6 +184,38 @@ class ThymeleafletRenderingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    @DisplayName("parser corpus の name() 形式 no-arg fragment 参照を描画できる")
+    void shouldRenderNoArgReferenceRegressionFixture() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/regression.parser-corpus/noArgReferenceShell/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Corpus topbar OK"),
+            "parser corpus の no-arg fragment を name() 形式で描画できること");
+        assertFalse(body.contains("Preview error"),
+            "no-arg parser corpus fixture がプレビューエラーにならないこと");
+    }
+
+    @Test
+    @DisplayName("parser corpus の nested fragment fixture を描画できる")
+    void shouldRenderNestedFragmentRegressionFixture() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/regression.parser-corpus/nestedFragmentShell/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Nested Label"),
+            "nested fragment fixture の子 fragment 参照を描画できること");
+        assertFalse(body.contains("Preview error"),
+            "nested parser corpus fixture がプレビューエラーにならないこと");
+    }
+
+    @Test
     @DisplayName("Map no-arg メソッドが未解決でも /render は継続し警告ヘッダーを返す")
     void shouldRenderWithWarningsForUnresolvedMapNoArgMethods() throws Exception {
         var mvcResult = mockMvc.perform(get("/thymeleaflet/test.map-noarg-warning/methodWarning/default/render")

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/FixtureResources.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/FixtureResources.java
@@ -1,0 +1,24 @@
+package io.github.wamukat.thymeleaflet.testsupport;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public final class FixtureResources {
+
+    private FixtureResources() {
+    }
+
+    public static String text(String resourcePath) {
+        Objects.requireNonNull(resourcePath, "resourcePath cannot be null");
+        ClassLoader classLoader = FixtureResources.class.getClassLoader();
+        try (var inputStream = classLoader.getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IllegalArgumentException("Fixture resource not found: " + resourcePath);
+            }
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Failed to read fixture resource: " + resourcePath, exception);
+        }
+    }
+}

--- a/src/test/resources/META-INF/thymeleaflet/stories/regression/parser-corpus.stories.yml
+++ b/src/test/resources/META-INF/thymeleaflet/stories/regression/parser-corpus.stories.yml
@@ -15,3 +15,15 @@ storyGroups:
         model:
           view:
             label: Quoted Label
+  noArgReferenceShell:
+    stories:
+      - name: default
+        title: no-arg reference
+  nestedFragmentShell:
+    stories:
+      - name: default
+        title: nested fragment shell
+        model:
+          view:
+            nested:
+              title: Nested Label

--- a/src/test/resources/templates/regression/parser-corpus.html
+++ b/src/test/resources/templates/regression/parser-corpus.html
@@ -26,5 +26,45 @@
 </section>
 
 <span th:fragment="quotedTarget(label)" th:text="${label}">Label</span>
+
+<!--
+ /**
+  * Parser regression corpus for no-arg fragment references with empty parentheses.
+  * Protects GH-149-style calls where a no-arg child fragment is referenced as name().
+  * @fragment noArgReferenceShell
+  */
+-->
+<section th:fragment="noArgReferenceShell">
+  <div th:replace="~{regression/parser-corpus :: noArgReferenceTarget()}"></div>
+</section>
+
+<header th:fragment="noArgReferenceTarget">Corpus topbar OK</header>
+
+<!--
+ /**
+  * Parser regression corpus for nested fragments and subtree extraction.
+  * @fragment nestedFragmentShell
+  * @model view.nested.title {@code String} [required] Nested title
+  */
+-->
+<article th:fragment="nestedFragmentShell">
+  <section>
+    <div th:fragment="nestedChild(title)" th:text="${title}">Nested title</div>
+    <th:block th:replace="~{regression/parser-corpus :: quotedTarget(label=${view.nested.title})}"></th:block>
+  </section>
+</article>
+
+<!--
+ /**
+  * Parser regression corpus for malformed-but-browser-tolerated HTML.
+  * Keeps structured parser coverage separate from render coverage.
+  * @fragment malformedHtmlShell
+  * @model view.malformed.label {@code String} [required] Malformed label
+  */
+-->
+<section th:fragment="malformedHtmlShell">
+  <div>
+    <span data-th-text="${view.malformed.label}">Malformed label
+</section>
 </body>
 </html>

--- a/tests/fixtures/central-publishing/published-release.txt
+++ b/tests/fixtures/central-publishing/published-release.txt
@@ -1,0 +1,5 @@
+[INFO] Uploading deployment bundle to Central Publishing
+[INFO] Created deployment id: 22222222-2222-2222-2222-222222222222
+[INFO] Deployment 22222222-2222-2222-2222-222222222222 has been published
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS

--- a/tests/node/summarize-central-publish.test.js
+++ b/tests/node/summarize-central-publish.test.js
@@ -40,6 +40,18 @@ test('parseCentralPublishStatus distinguishes uploaded, validated, and published
   assert.equal(parseCentralPublishStatus('Deployment artifact published for 33333333-3333-3333-3333-333333333333').status, 'published');
 });
 
+test('parseCentralPublishStatus reads published release log fixture', () => {
+  const log = fs.readFileSync('tests/fixtures/central-publishing/published-release.txt', 'utf8');
+
+  const summary = parseCentralPublishStatus(log);
+
+  assert.deepEqual(summary, {
+    deploymentId: '22222222-2222-2222-2222-222222222222',
+    status: 'published',
+    manualPublishUrl: '',
+  });
+});
+
 test('parseCentralPublishStatus handles Central state-token wording', () => {
   assert.equal(
     parseCentralPublishStatus('Deployment 44444444-4444-4444-4444-444444444444 has been VALIDATED').status,


### PR DESCRIPTION
## Summary
- Expand the parser regression corpus with fixture-backed coverage for no-arg references, quoted selectors, data-th attributes, nested fragments, and malformed HTML parsing.
- Add a shared test fixture resource reader and move parser/model assertions toward fixture-driven coverage.
- Add an additional Central published release log fixture for release status parsing.

## Verification
- `./mvnw -q -Dtest=StructuredTemplateParserTest,TemplateModelExpressionAnalyzerTest,ThymeleafletRenderingExceptionHandlerIntegrationTest test`
- `node --test tests/node/summarize-central-publish.test.js`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local`
- `git diff --check`

## Tracking
Kanban: #498
Closes: N/A
