### PR TITLE
Introduce shared fragment expression parser

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/FragmentExpression.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/FragmentExpression.java
@@ -1,0 +1,62 @@
+package io.github.wamukat.thymeleaflet.domain.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class FragmentExpression {
+
+    private final String templatePath;
+    private final String fragmentName;
+    private final List<String> arguments;
+    private final boolean hasArgumentList;
+
+    private FragmentExpression(
+        String templatePath,
+        String fragmentName,
+        List<String> arguments,
+        boolean hasArgumentList
+    ) {
+        if (templatePath.isBlank()) {
+            throw new IllegalArgumentException("templatePath cannot be blank");
+        }
+        if (fragmentName.isBlank()) {
+            throw new IllegalArgumentException("fragmentName cannot be blank");
+        }
+        this.templatePath = templatePath;
+        this.fragmentName = fragmentName;
+        this.arguments = List.copyOf(arguments);
+        this.hasArgumentList = hasArgumentList;
+    }
+
+    public static FragmentExpression of(String templatePath, String fragmentName, List<String> arguments) {
+        return of(templatePath, fragmentName, arguments, false);
+    }
+
+    public static FragmentExpression of(
+        String templatePath,
+        String fragmentName,
+        List<String> arguments,
+        boolean hasArgumentList
+    ) {
+        Objects.requireNonNull(templatePath, "templatePath cannot be null");
+        Objects.requireNonNull(fragmentName, "fragmentName cannot be null");
+        Objects.requireNonNull(arguments, "arguments cannot be null");
+        return new FragmentExpression(templatePath.trim(), fragmentName.trim(), arguments, hasArgumentList);
+    }
+
+    public String templatePath() {
+        return templatePath;
+    }
+
+    public String fragmentName() {
+        return fragmentName;
+    }
+
+    public List<String> arguments() {
+        return arguments;
+    }
+
+    public boolean hasArgumentList() {
+        return hasArgumentList;
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
@@ -1,0 +1,178 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class FragmentExpressionParser {
+
+    public Optional<FragmentExpression> parse(String rawExpression) {
+        if (rawExpression == null || rawExpression.isBlank()) {
+            return Optional.empty();
+        }
+        String expression = unwrapFragmentExpression(rawExpression.trim());
+        if (expression.isBlank()
+            || expression.startsWith("${")
+            || expression.startsWith("*{")
+            || expression.startsWith("#{")) {
+            return Optional.empty();
+        }
+
+        int separatorIndex = findTopLevelFragmentSeparator(expression);
+        if (separatorIndex <= 0 || separatorIndex >= expression.length() - 2) {
+            return Optional.empty();
+        }
+
+        String templatePath = normalizeTemplatePath(expression.substring(0, separatorIndex));
+        Optional<FragmentSelector> selector = parseFragmentSelector(expression.substring(separatorIndex + 2));
+        if (templatePath.isBlank() || selector.isEmpty()) {
+            return Optional.empty();
+        }
+        FragmentSelector resolvedSelector = selector.orElseThrow();
+        return Optional.of(FragmentExpression.of(
+            templatePath,
+            resolvedSelector.name(),
+            resolvedSelector.arguments(),
+            resolvedSelector.hasArgumentList()
+        ));
+    }
+
+    private String unwrapFragmentExpression(String rawExpression) {
+        if (rawExpression.startsWith("~{") && rawExpression.endsWith("}")) {
+            return rawExpression.substring(2, rawExpression.length() - 1).trim();
+        }
+        return rawExpression;
+    }
+
+    private int findTopLevelFragmentSeparator(String expression) {
+        ScanState state = new ScanState();
+        for (int index = 0; index < expression.length() - 1; index++) {
+            state.accept(expression.charAt(index));
+            if (!state.isInsideNestedSyntax()
+                && expression.charAt(index) == ':'
+                && expression.charAt(index + 1) == ':') {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private String normalizeTemplatePath(String rawTemplatePath) {
+        String templatePath = unquote(rawTemplatePath.trim());
+        if (templatePath.startsWith("/") && templatePath.length() > 1) {
+            templatePath = templatePath.substring(1);
+        }
+        if (templatePath.startsWith("#") || templatePath.startsWith("this") || templatePath.contains("${")) {
+            return "";
+        }
+        return templatePath;
+    }
+
+    private Optional<FragmentSelector> parseFragmentSelector(String rawSelector) {
+        String selector = unquote(rawSelector.trim());
+        if (selector.isBlank()) {
+            return Optional.empty();
+        }
+        int openParen = selector.indexOf('(');
+        if (openParen < 0) {
+            return Optional.of(new FragmentSelector(unquote(selector), List.of(), false));
+        }
+        int closeParen = selector.lastIndexOf(')');
+        if (closeParen < openParen || closeParen != selector.length() - 1) {
+            return Optional.empty();
+        }
+        String fragmentName = unquote(selector.substring(0, openParen).trim());
+        if (fragmentName.isBlank()) {
+            return Optional.empty();
+        }
+        Optional<List<String>> arguments = splitTopLevel(selector.substring(openParen + 1, closeParen), ',');
+        return arguments.map(values -> new FragmentSelector(fragmentName, values, true));
+    }
+
+    private Optional<List<String>> splitTopLevel(String value, char separator) {
+        List<String> segments = new ArrayList<>();
+        ScanState state = new ScanState();
+        int segmentStart = 0;
+
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            state.accept(current);
+            if (!state.isInsideNestedSyntax() && current == separator) {
+                addSegment(segments, value.substring(segmentStart, index));
+                segmentStart = index + 1;
+            }
+        }
+        if (!state.isBalanced()) {
+            return Optional.empty();
+        }
+        addSegment(segments, value.substring(segmentStart));
+        return Optional.of(segments);
+    }
+
+    private void addSegment(List<String> segments, String segment) {
+        String normalized = segment.trim();
+        if (!normalized.isEmpty()) {
+            segments.add(normalized);
+        }
+    }
+
+    private String unquote(String value) {
+        if (value.length() >= 2
+            && ((value.startsWith("'") && value.endsWith("'"))
+            || (value.startsWith("\"") && value.endsWith("\"")))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private record FragmentSelector(String name, List<String> arguments, boolean hasArgumentList) {
+    }
+
+    private static final class ScanState {
+        private int depthParen;
+        private int depthBracket;
+        private int depthBrace;
+        private boolean inSingleQuote;
+        private boolean inDoubleQuote;
+        private char previous;
+
+        private void accept(char current) {
+            if (current == '\'' && !inDoubleQuote && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+                previous = current;
+                return;
+            }
+            if (current == '"' && !inSingleQuote && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+                previous = current;
+                return;
+            }
+            if (!inSingleQuote && !inDoubleQuote) {
+                if (current == '(') {
+                    depthParen++;
+                } else if (current == ')' && depthParen > 0) {
+                    depthParen--;
+                } else if (current == '[') {
+                    depthBracket++;
+                } else if (current == ']' && depthBracket > 0) {
+                    depthBracket--;
+                } else if (current == '{') {
+                    depthBrace++;
+                } else if (current == '}' && depthBrace > 0) {
+                    depthBrace--;
+                }
+            }
+            previous = current;
+        }
+
+        private boolean isInsideNestedSyntax() {
+            return inSingleQuote || inDoubleQuote || depthParen > 0 || depthBracket > 0 || depthBrace > 0;
+        }
+
+        private boolean isBalanced() {
+            return !inSingleQuote && !inDoubleQuote && depthParen == 0 && depthBracket == 0 && depthBrace == 0;
+        }
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -1,6 +1,7 @@
 package io.github.wamukat.thymeleaflet.domain.service;
 
 import io.github.wamukat.thymeleaflet.domain.model.ModelPath;
+import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 import io.github.wamukat.thymeleaflet.domain.model.TemplateInference;
 import org.jspecify.annotations.Nullable;
 
@@ -25,13 +26,22 @@ public class TemplateModelExpressionAnalyzer {
         "instanceof", "matches", "div", "mod"
     );
     private final StructuredTemplateParser templateParser;
+    private final FragmentExpressionParser fragmentExpressionParser;
 
     public TemplateModelExpressionAnalyzer() {
-        this(new StructuredTemplateParser());
+        this(new StructuredTemplateParser(), new FragmentExpressionParser());
     }
 
     TemplateModelExpressionAnalyzer(StructuredTemplateParser templateParser) {
+        this(templateParser, new FragmentExpressionParser());
+    }
+
+    TemplateModelExpressionAnalyzer(
+        StructuredTemplateParser templateParser,
+        FragmentExpressionParser fragmentExpressionParser
+    ) {
         this.templateParser = templateParser;
+        this.fragmentExpressionParser = fragmentExpressionParser;
     }
 
     public TemplateInference analyze(String html, Set<String> parameterNames) {
@@ -191,51 +201,21 @@ public class TemplateModelExpressionAnalyzer {
             if (raw == null || raw.isBlank()) {
                 continue;
             }
-            String expression = raw.trim();
-            if (expression.startsWith("${") || expression.startsWith("*{") || expression.startsWith("#{")) {
-                continue;
-            }
-            if (expression.startsWith("~{") && expression.endsWith("}")) {
-                expression = expression.substring(2, expression.length() - 1).trim();
-            }
-            int fragmentSeparator = expression.indexOf("::");
-            if (fragmentSeparator <= 0) {
-                continue;
-            }
-            String candidatePath = expression.substring(0, fragmentSeparator).trim();
-            if (candidatePath.isEmpty() || candidatePath.startsWith("#") || candidatePath.startsWith("this")) {
-                continue;
-            }
-            if (candidatePath.startsWith("'") && candidatePath.endsWith("'") && candidatePath.length() >= 2) {
-                candidatePath = candidatePath.substring(1, candidatePath.length() - 1);
-            } else if (candidatePath.startsWith("\"") && candidatePath.endsWith("\"") && candidatePath.length() >= 2) {
-                candidatePath = candidatePath.substring(1, candidatePath.length() - 1);
-            }
-            if (candidatePath.startsWith("/")) {
-                candidatePath = candidatePath.substring(1);
-            }
-            if (!candidatePath.isEmpty()) {
-                boolean requiresRecursion = requiresChildModelRecursion(expression, fragmentSeparator);
-                referencedTemplatePaths.merge(candidatePath, requiresRecursion, (left, right) -> left || right);
-            }
+            fragmentExpressionParser.parse(raw)
+                .ifPresent(expression -> referencedTemplatePaths.merge(
+                    expression.templatePath(),
+                    requiresChildModelRecursion(expression),
+                    (left, right) -> left || right
+                ));
         }
         return referencedTemplatePaths;
     }
 
-    private boolean requiresChildModelRecursion(String expression, int fragmentSeparator) {
-        int openParen = expression.indexOf('(', fragmentSeparator);
-        if (openParen < 0) {
-            return true;
+    private boolean requiresChildModelRecursion(FragmentExpression expression) {
+        if (expression.arguments().isEmpty()) {
+            return !expression.hasArgumentList();
         }
-        int closeParen = expression.lastIndexOf(')');
-        if (closeParen < openParen) {
-            return true;
-        }
-        String argumentsText = expression.substring(openParen + 1, closeParen).trim();
-        if (argumentsText.isEmpty()) {
-            return false;
-        }
-        for (String argument : splitTopLevel(argumentsText, ',')) {
+        for (String argument : expression.arguments()) {
             if (argument.isBlank()) {
                 continue;
             }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
@@ -1,11 +1,12 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
+import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,9 +18,11 @@ final class JavaDocExampleParser {
     private static final Set<String> EXAMPLE_REPLACE_ATTRIBUTES = Set.of("th:replace", "data-th-replace");
 
     private final StructuredTemplateParser templateParser;
+    private final FragmentExpressionParser fragmentExpressionParser;
 
     JavaDocExampleParser(StructuredTemplateParser templateParser) {
         this.templateParser = Objects.requireNonNull(templateParser, "templateParser cannot be null");
+        this.fragmentExpressionParser = new FragmentExpressionParser();
     }
 
     List<JavaDocAnalyzer.ExampleInfo> parse(String javadocContent) {
@@ -111,57 +114,15 @@ final class JavaDocExampleParser {
     }
 
     private Optional<JavaDocAnalyzer.ExampleInfo> parseExampleReference(String rawReference) {
-        String expression = rawReference.trim();
-        if (expression.startsWith("~{") && expression.endsWith("}")) {
-            expression = expression.substring(2, expression.length() - 1).trim();
-        }
-        int fragmentSeparator = expression.indexOf("::");
-        if (fragmentSeparator <= 0) {
-            return Optional.empty();
-        }
-        String templatePath = unquote(expression.substring(0, fragmentSeparator).trim());
-        String fragmentExpression = expression.substring(fragmentSeparator + 2).trim();
-        if (templatePath.isBlank() || fragmentExpression.isBlank()) {
-            return Optional.empty();
-        }
-        String fragmentName = fragmentExpression;
-        String argumentsStr = "";
-        int openParen = fragmentExpression.indexOf('(');
-        if (openParen >= 0) {
-            int closeParen = fragmentExpression.lastIndexOf(')');
-            if (closeParen < openParen) {
-                return Optional.empty();
-            }
-            fragmentName = fragmentExpression.substring(0, openParen).trim();
-            argumentsStr = fragmentExpression.substring(openParen + 1, closeParen).trim();
-        }
-        if (fragmentName.isBlank()) {
-            return Optional.empty();
-        }
-        return Optional.of(JavaDocAnalyzer.ExampleInfo.of(templatePath, fragmentName, parseArguments(argumentsStr)));
+        return fragmentExpressionParser.parse(rawReference)
+            .map(this::toExampleInfo);
     }
 
-    private String unquote(String value) {
-        String trimmed = value.trim();
-        if (trimmed.length() >= 2
-            && ((trimmed.startsWith("'") && trimmed.endsWith("'"))
-            || (trimmed.startsWith("\"") && trimmed.endsWith("\"")))) {
-            return trimmed.substring(1, trimmed.length() - 1);
-        }
-        return trimmed;
-    }
-
-    private List<String> parseArguments(String argumentsStr) {
-        if (argumentsStr.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<String> arguments = new ArrayList<>();
-        String[] parts = argumentsStr.split(",(?=(?:[^']*'[^']*')*[^']*$)");
-        for (String part : parts) {
-            arguments.add(part.trim());
-        }
-
-        return arguments;
+    private JavaDocAnalyzer.ExampleInfo toExampleInfo(FragmentExpression expression) {
+        return JavaDocAnalyzer.ExampleInfo.of(
+            expression.templatePath(),
+            expression.fragmentName(),
+            expression.arguments()
+        );
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -1,7 +1,9 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentDependencyPort;
+import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.configuration.ResourcePathValidator;
@@ -42,6 +44,7 @@ public class FragmentDependencyService implements FragmentDependencyPort {
     private final ThymeleafletCacheManager cacheManager;
 
     private final StructuredTemplateParser templateParser;
+    private final FragmentExpressionParser fragmentExpressionParser;
 
     @Autowired
     public FragmentDependencyService(
@@ -49,7 +52,7 @@ public class FragmentDependencyService implements FragmentDependencyPort {
         ResourcePathValidator resourcePathValidator,
         ThymeleafletCacheManager cacheManager
     ) {
-        this(storybookConfig, resourcePathValidator, cacheManager, new StructuredTemplateParser());
+        this(storybookConfig, resourcePathValidator, cacheManager, new StructuredTemplateParser(), new FragmentExpressionParser());
     }
 
     FragmentDependencyService(
@@ -58,10 +61,21 @@ public class FragmentDependencyService implements FragmentDependencyPort {
         ThymeleafletCacheManager cacheManager,
         StructuredTemplateParser templateParser
     ) {
+        this(storybookConfig, resourcePathValidator, cacheManager, templateParser, new FragmentExpressionParser());
+    }
+
+    FragmentDependencyService(
+        ResolvedStorybookConfig storybookConfig,
+        ResourcePathValidator resourcePathValidator,
+        ThymeleafletCacheManager cacheManager,
+        StructuredTemplateParser templateParser,
+        FragmentExpressionParser fragmentExpressionParser
+    ) {
         this.storybookConfig = storybookConfig;
         this.resourcePathValidator = resourcePathValidator;
         this.cacheManager = cacheManager;
         this.templateParser = templateParser;
+        this.fragmentExpressionParser = fragmentExpressionParser;
     }
 
     public List<DependencyComponent> findDependencies(String templatePath, String fragmentName) {
@@ -119,21 +133,13 @@ public class FragmentDependencyService implements FragmentDependencyPort {
     }
 
     private Optional<DependencyComponent> parseDependency(String expression) {
-        String normalizedExpression = unwrapFragmentExpression(expression);
-        String[] parts = normalizedExpression.split("::", 2);
-        if (parts.length < 2) {
-            return Optional.empty();
-        }
-        String templatePath = unquote(parts[0].trim());
-        String fragmentPart = parts[1].trim();
-        String fragmentName = fragmentPart.split("\\(")[0].trim();
+        return fragmentExpressionParser.parse(expression)
+            .map(this::toDependencyComponent);
+    }
 
-        if (templatePath.isEmpty() || fragmentName.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String encodedPath = SecureTemplatePath.createUnsafe(templatePath.replace("/", ".")).forUrl();
-        return Optional.of(new DependencyComponent(templatePath, fragmentName, encodedPath));
+    private DependencyComponent toDependencyComponent(FragmentExpression expression) {
+        String encodedPath = SecureTemplatePath.createUnsafe(expression.templatePath().replace("/", ".")).forUrl();
+        return new DependencyComponent(expression.templatePath(), expression.fragmentName(), encodedPath);
     }
 
     private List<String> extractDependencyExpressions(List<StructuredTemplateParser.TemplateElement> elements) {
@@ -169,24 +175,6 @@ public class FragmentDependencyService implements FragmentDependencyPort {
             .map(StructuredTemplateParser.TemplateAttribute::value)
             .map(String::trim)
             .findFirst();
-    }
-
-    private String unwrapFragmentExpression(String expression) {
-        String normalized = expression.trim();
-        if (normalized.startsWith("~{") && normalized.endsWith("}")) {
-            return normalized.substring(2, normalized.length() - 1).trim();
-        }
-        return normalized;
-    }
-
-    private String unquote(String value) {
-        if (value.length() < 2) {
-            return value;
-        }
-        if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith("\"") && value.endsWith("\""))) {
-            return value.substring(1, value.length() - 1);
-        }
-        return value;
     }
 
     public record DependencyComponent(String templatePath, String fragmentName, String encodedTemplatePath) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
@@ -1,0 +1,52 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
+import org.junit.jupiter.api.Test;
+
+class FragmentExpressionParserTest {
+
+    private final FragmentExpressionParser parser = new FragmentExpressionParser();
+
+    @Test
+    void parse_shouldReadTemplateFragmentAndArguments() {
+        FragmentExpression expression = parser.parse("~{components/card :: card(title=${view.title}, variant='primary')}")
+            .orElseThrow();
+
+        assertThat(expression.templatePath()).isEqualTo("components/card");
+        assertThat(expression.fragmentName()).isEqualTo("card");
+        assertThat(expression.arguments()).containsExactly("title=${view.title}", "variant='primary'");
+    }
+
+    @Test
+    void parse_shouldSupportQuotedTemplatePathAndNoArgFragment() {
+        FragmentExpression expression = parser.parse("~{'components/topbar' :: 'topbar()'}")
+            .orElseThrow();
+
+        assertThat(expression.templatePath()).isEqualTo("components/topbar");
+        assertThat(expression.fragmentName()).isEqualTo("topbar");
+        assertThat(expression.arguments()).isEmpty();
+    }
+
+    @Test
+    void parse_shouldSupportPositionalArgumentsWithNestedSyntax() {
+        FragmentExpression expression = parser.parse(
+                "~{components/list :: item(${view.items[0].label}, ${#temporals.format(view.date, 'yyyy, MM')})}"
+            )
+            .orElseThrow();
+
+        assertThat(expression.templatePath()).isEqualTo("components/list");
+        assertThat(expression.fragmentName()).isEqualTo("item");
+        assertThat(expression.arguments())
+            .containsExactly("${view.items[0].label}", "${#temporals.format(view.date, 'yyyy, MM')}");
+    }
+
+    @Test
+    void parse_shouldFailClosedForMalformedOrDynamicInput() {
+        assertThat(parser.parse("${dynamicRef}")).isEmpty();
+        assertThat(parser.parse("~{components/card}")).isEmpty();
+        assertThat(parser.parse("~{components/card :: card(label=${view.title)}")).isEmpty();
+        assertThat(parser.parse("~{${dynamicPath} :: card()}")).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared `FragmentExpression` value object and `FragmentExpressionParser` for Thymeleaf fragment references.
- Migrate model inference, dependency extraction, and JavaDoc example parsing to the shared parser.
- Cover quoted paths, no-arg selectors, named/positional args, nested syntax, and fail-closed malformed/dynamic input.

## Verification
- `./mvnw -q -Dtest=FragmentExpressionParserTest test`
- `./mvnw -q -Dtest=FragmentExpressionParserTest,TemplateModelExpressionAnalyzerTest,FragmentDependencyServiceTest,JavaDocAnalyzerTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local`
- `git diff --check`

## Tracking
Kanban: #499
Closes: N/A
