### PR TITLE
Expand structured parser edge corpus

### DIFF
--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
@@ -148,7 +148,10 @@ class StructuredTemplateParserTest {
                 "noArgReferenceTarget",
                 "nestedFragmentShell",
                 "nestedChild(title)",
-                "malformedHtmlShell"
+                "malformedHtmlShell",
+                "mixedDependencyShell",
+                "siblingBoundaryA",
+                "siblingBoundaryB"
             );
         assertThat(parsed.elements())
             .anySatisfy(element -> assertThat(element.attributeValue("data-th-each"))
@@ -158,16 +161,74 @@ class StructuredTemplateParserTest {
             .anySatisfy(element -> assertThat(element.attributeValue("th:replace"))
                 .hasValue("~{regression/parser-corpus :: noArgReferenceTarget()}"))
             .anySatisfy(element -> assertThat(element.attributeValue("data-th-text"))
-                .hasValue("${view.malformed.label}"));
+                .hasValue("${view.malformed.label}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("th:include"))
+                .hasValue("~{regression/parser-corpus :: nestedChild(title='Included > Nested')}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("data-th-include"))
+                .hasValue("~{regression/parser-corpus :: nestedChild(title=${view.mixed.title})}"))
+            .anySatisfy(element -> assertThat(element.attributeValue("data-th-value"))
+                .hasValue("${view.mixed.title}"));
         assertThat(parsed.comments())
             .extracting(StructuredTemplateParser.TemplateComment::content)
             .anySatisfy(comment -> assertThat(comment).contains("GH-149-style"))
-            .anySatisfy(comment -> assertThat(comment).contains("malformed-but-browser-tolerated HTML"));
+            .anySatisfy(comment -> assertThat(comment).contains("malformed-but-browser-tolerated HTML"))
+            .anySatisfy(comment -> assertThat(comment).contains("commented.out"));
+        assertThat(parsed.textNodes())
+            .extracting(StructuredTemplateParser.TemplateText::content)
+            .anySatisfy(text -> assertThat(text).contains("Hello ${view.mixed.title}"))
+            .noneSatisfy(text -> assertThat(text).contains("commented.out"));
+    }
+
+    @Test
+    void parse_shouldExposeExpectedSubtreesForRegressionCorpusSiblings() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        StructuredTemplateParser.ParsedTemplate parsed = parser.parse(html);
+
+        assertThat(attributeValues(parsed.subtree(fragmentElement(parsed, "nestedFragmentShell")), "th:fragment"))
+            .contains("nestedFragmentShell", "nestedChild(title)");
+        assertThat(attributeValues(parsed.subtree(fragmentElement(parsed, "siblingBoundaryA")), "th:text"))
+            .contains("${view.boundary.a}")
+            .doesNotContain("${view.boundary.b}");
+        assertThat(attributeValues(parsed.subtree(fragmentElement(parsed, "siblingBoundaryB")), "th:text"))
+            .contains("${view.boundary.b}")
+            .doesNotContain("${view.boundary.a}");
+        assertThat(parsed.subtree(fragmentElement(parsed, "mixedDependencyShell")))
+            .flatExtracting(StructuredTemplateParser.TemplateElement::thymeleafAttributes)
+            .extracting(StructuredTemplateParser.TemplateAttribute::name)
+            .contains(
+                "th:replace",
+                "th:insert",
+                "th:include",
+                "data-th-replace",
+                "data-th-insert",
+                "data-th-include",
+                "data-th-value"
+            );
     }
 
     private static java.util.List<String> fragmentDefinitions(StructuredTemplateParser.ParsedTemplate parsed) {
         return parsed.elements().stream()
             .flatMap(element -> element.attributeValue("th:fragment").stream())
+            .toList();
+    }
+
+    private static StructuredTemplateParser.TemplateElement fragmentElement(
+        StructuredTemplateParser.ParsedTemplate parsed,
+        String fragmentName
+    ) {
+        return parsed.elements().stream()
+            .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private static java.util.List<String> attributeValues(
+        java.util.List<StructuredTemplateParser.TemplateElement> elements,
+        String attributeName
+    ) {
+        return elements.stream()
+            .flatMap(element -> element.attributeValue(attributeName).stream())
             .toList();
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
@@ -216,6 +216,22 @@ class ThymeleafletRenderingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    @DisplayName("parser corpus の mixed dependency fixture を描画できる")
+    void shouldRenderMixedDependencyRegressionFixture() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/regression.parser-corpus/mixedDependencyShell/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Mixed Label"),
+            "mixed dependency fixture の model 値を描画できること");
+        assertFalse(body.contains("Preview error"),
+            "mixed dependency parser corpus fixture がプレビューエラーにならないこと");
+    }
+
+    @Test
     @DisplayName("Map no-arg メソッドが未解決でも /render は継続し警告ヘッダーを返す")
     void shouldRenderWithWarningsForUnresolvedMapNoArgMethods() throws Exception {
         var mvcResult = mockMvc.perform(get("/thymeleaflet/test.map-noarg-warning/methodWarning/default/render")

--- a/src/test/resources/META-INF/thymeleaflet/stories/regression/parser-corpus.stories.yml
+++ b/src/test/resources/META-INF/thymeleaflet/stories/regression/parser-corpus.stories.yml
@@ -27,3 +27,11 @@ storyGroups:
           view:
             nested:
               title: Nested Label
+  mixedDependencyShell:
+    stories:
+      - name: default
+        title: mixed dependency shell
+        model:
+          view:
+            mixed:
+              title: Mixed Label

--- a/src/test/resources/templates/regression/parser-corpus.html
+++ b/src/test/resources/templates/regression/parser-corpus.html
@@ -66,5 +66,40 @@
   <div>
     <span data-th-text="${view.malformed.label}">Malformed label
 </section>
+
+<!--
+ /**
+  * Parser regression corpus for mixed dependency attributes and text/comment extraction.
+  * Covers th:replace, th:insert, th:include, and data-th-* siblings with quoted > values.
+  * @fragment mixedDependencyShell
+  * @model view.mixed.title {@code String} [required] Mixed title
+  */
+-->
+<section th:fragment="mixedDependencyShell"
+         th:with="label='Ready > Draft', local=${view.mixed.title}">
+  <!-- Parser should keep ${commented.out} inside comments only. -->
+  Hello ${view.mixed.title}
+  <div th:replace="~{regression/parser-corpus :: quotedTarget(label=${view.mixed.title})}"></div>
+  <div th:insert="~{'regression/parser-corpus' :: noArgReferenceTarget()}"></div>
+  <div th:include="~{regression/parser-corpus :: nestedChild(title='Included > Nested')}"></div>
+  <span data-th-replace="~{'regression/parser-corpus' :: quotedTarget(label='Data > Replace')}"></span>
+  <span data-th-insert="~{regression/parser-corpus :: noArgReferenceTarget()}"></span>
+  <span data-th-include="~{regression/parser-corpus :: nestedChild(title=${view.mixed.title})}"></span>
+  <input disabled data-th-value="${view.mixed.title}" />
+</section>
+
+<!--
+ /**
+  * Parser regression corpus for sibling subtree boundaries.
+  * @fragment siblingBoundaryA
+  */
+-->
+<section th:fragment="siblingBoundaryA">
+  <span th:text="${view.boundary.a}">A</span>
+</section>
+
+<section th:fragment="siblingBoundaryB">
+  <span th:text="${view.boundary.b}">B</span>
+</section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Expand the structured parser regression corpus with mixed `th:*` and `data-th-*` dependency attributes, comment/text cases, malformed HTML, and nested/sibling fragment boundaries.
- Add explicit parser assertions for attribute values, comment/text extraction, and subtree boundaries.
- Add rendering integration coverage for the mixed dependency fixture.

## Verification
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

Kanban: #500
Closes: N/A
