### PR TITLE
Replace JavaDoc field regex parsing

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParser.java
@@ -9,16 +9,6 @@ import java.util.regex.Pattern;
 
 final class JavaDocTagParser {
 
-    private static final Pattern PARAM_PATTERN = Pattern.compile(
-        "@param\\s+(\\w+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*)",
-        Pattern.DOTALL
-    );
-
-    private static final Pattern MODEL_PATTERN = Pattern.compile(
-        "@model\\s+([\\w.\\[\\]]+)\\s+\\{@code\\s+([^}]+?)\\}\\s+\\[(required|optional(?:=[^\\]]*)?)\\]\\s+([\\s\\S]*)",
-        Pattern.DOTALL
-    );
-
     private static final Pattern FRAGMENT_PATTERN = Pattern.compile(
         "@fragment\\s+([A-Za-z_][\\w-]*)",
         Pattern.MULTILINE
@@ -52,20 +42,18 @@ final class JavaDocTagParser {
         List<JavaDocAnalyzer.ParameterInfo> parameters = new ArrayList<>();
 
         for (String tagBlock : tagBlocks) {
-            Matcher paramMatcher = PARAM_PATTERN.matcher(tagBlock);
-            if (!paramMatcher.matches()) {
+            Optional<ParsedFieldTag> parsedTag = parseFieldTag(tagBlock, "param");
+            if (parsedTag.isEmpty()) {
                 continue;
             }
-            String name = paramMatcher.group(1);
-            String type = paramMatcher.group(2);
-            String requiredOrOptional = paramMatcher.group(3);
-            ParsedDescription parsedDescription = parseDescriptionWithAllowedValues(paramMatcher.group(4));
+            ParsedFieldTag fieldTag = parsedTag.get();
+            ParsedDescription parsedDescription = parseDescriptionWithAllowedValues(fieldTag.description());
 
             parameters.add(JavaDocAnalyzer.ParameterInfo.of(
-                name,
-                type,
-                "required".equals(requiredOrOptional),
-                parseDefaultValue(requiredOrOptional),
+                fieldTag.identifier(),
+                fieldTag.type(),
+                fieldTag.required(),
+                fieldTag.defaultValue(),
                 Optional.of(parsedDescription.description()),
                 parsedDescription.allowedValues()
             ));
@@ -78,36 +66,43 @@ final class JavaDocTagParser {
         List<JavaDocAnalyzer.ModelInfo> models = new ArrayList<>();
 
         for (String tagBlock : tagBlocks) {
-            Matcher modelMatcher = MODEL_PATTERN.matcher(tagBlock);
-            if (!modelMatcher.matches()) {
+            Optional<ParsedFieldTag> parsedTag = parseFieldTag(tagBlock, "model");
+            if (parsedTag.isEmpty()) {
                 continue;
             }
-            String name = modelMatcher.group(1);
-            String type = modelMatcher.group(2);
-            String requiredOrOptional = modelMatcher.group(3);
-            String description = normalizeDescription(modelMatcher.group(4));
+            ParsedFieldTag fieldTag = parsedTag.get();
 
             models.add(JavaDocAnalyzer.ModelInfo.of(
-                name,
-                type,
-                "required".equals(requiredOrOptional),
-                parseDefaultValue(requiredOrOptional),
-                Optional.of(description)
+                fieldTag.identifier(),
+                fieldTag.type(),
+                fieldTag.required(),
+                fieldTag.defaultValue(),
+                Optional.of(normalizeDescription(fieldTag.description()))
             ));
         }
 
         return models;
     }
 
-    private Optional<String> parseDefaultValue(String requiredOrOptional) {
-        if (!requiredOrOptional.startsWith("optional=")) {
+    private Optional<ParsedFieldTag> parseFieldTag(String tagBlock, String expectedTagName) {
+        TagCursor cursor = new TagCursor(tagBlock);
+        Optional<String> tagName = cursor.readTagName();
+        if (tagName.isEmpty() || !expectedTagName.equals(tagName.get())) {
             return Optional.empty();
         }
-        String rawDefaultValue = requiredOrOptional.substring("optional=".length());
-        if ("null".equals(rawDefaultValue)) {
+        Optional<String> identifier = cursor.readIdentifier();
+        Optional<String> type = cursor.readCodeLiteral();
+        Optional<ParsedMarker> marker = cursor.readMarker();
+        if (identifier.isEmpty() || type.isEmpty() || marker.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(rawDefaultValue);
+        return Optional.of(new ParsedFieldTag(
+            identifier.get(),
+            type.get(),
+            marker.get().required(),
+            marker.get().defaultValue(),
+            cursor.remainingDescription()
+        ));
     }
 
     private ParsedDescription parseDescriptionWithAllowedValues(String fullDescription) {
@@ -214,7 +209,10 @@ final class JavaDocTagParser {
     private String normalizeJavadocLine(String rawLine) {
         String line = rawLine.trim();
         if (line.startsWith("*")) {
-            return line.substring(1).trim();
+            line = line.substring(1).trim();
+        }
+        if (line.equals("/")) {
+            return "";
         }
         return line;
     }
@@ -233,5 +231,116 @@ final class JavaDocTagParser {
     }
 
     private record ParsedDescription(String description, List<String> allowedValues) {
+    }
+
+    private record ParsedFieldTag(
+        String identifier,
+        String type,
+        boolean required,
+        Optional<String> defaultValue,
+        String description
+    ) {
+    }
+
+    private record ParsedMarker(boolean required, Optional<String> defaultValue) {
+    }
+
+    private static final class TagCursor {
+        private static final String CODE_PREFIX = "{@code";
+        private final String source;
+        private int index;
+
+        private TagCursor(String source) {
+            this.source = source;
+        }
+
+        private Optional<String> readTagName() {
+            skipWhitespace();
+            if (!consume('@')) {
+                return Optional.empty();
+            }
+            return readUntilWhitespace()
+                .filter(tagName -> !tagName.isBlank());
+        }
+
+        private Optional<String> readIdentifier() {
+            skipWhitespace();
+            return readUntilWhitespace()
+                .filter(identifier -> !identifier.isBlank());
+        }
+
+        private Optional<String> readCodeLiteral() {
+            skipWhitespace();
+            if (!source.startsWith(CODE_PREFIX, index)) {
+                return Optional.empty();
+            }
+            index += CODE_PREFIX.length();
+            int end = source.indexOf('}', index);
+            if (end < 0) {
+                return Optional.empty();
+            }
+            String codeLiteral = source.substring(index, end).trim();
+            index = end + 1;
+            if (codeLiteral.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(codeLiteral);
+        }
+
+        private Optional<ParsedMarker> readMarker() {
+            skipWhitespace();
+            if (!consume('[')) {
+                return Optional.empty();
+            }
+            int end = source.indexOf(']', index);
+            if (end < 0) {
+                return Optional.empty();
+            }
+            String marker = source.substring(index, end).trim();
+            index = end + 1;
+            if ("required".equals(marker)) {
+                return Optional.of(new ParsedMarker(true, Optional.empty()));
+            }
+            if ("optional".equals(marker)) {
+                return Optional.of(new ParsedMarker(false, Optional.empty()));
+            }
+            if (marker.startsWith("optional=")) {
+                String defaultValue = marker.substring("optional=".length());
+                if (defaultValue.isBlank() || "null".equals(defaultValue)) {
+                    return Optional.of(new ParsedMarker(false, Optional.empty()));
+                }
+                return Optional.of(new ParsedMarker(false, Optional.of(defaultValue)));
+            }
+            return Optional.empty();
+        }
+
+        private String remainingDescription() {
+            return source.substring(index).trim();
+        }
+
+        private Optional<String> readUntilWhitespace() {
+            int start = index;
+            while (index < source.length() && !Character.isWhitespace(source.charAt(index))) {
+                index++;
+            }
+            if (start == index) {
+                return Optional.empty();
+            }
+            return Optional.of(source.substring(start, index));
+        }
+
+        private boolean consume(char expected) {
+            if (index >= source.length() || source.charAt(index) != expected) {
+                return false;
+            }
+            index++;
+            return true;
+        }
+
+        private void skipWhitespace() {
+            while (index < source.length() && Character.isWhitespace(source.charAt(index))) {
+                index++;
+            }
+        }
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocAnalyzerTest.java
@@ -389,6 +389,47 @@ class JavaDocAnalyzerTest {
     }
 
     @Test
+    @DisplayName("JavaDocAnalyzer 経由で generic 型と複数行タグ説明を解析できる")
+    void shouldAnalyzeGenericJavaDocTagsWithMultilineDescriptions() {
+        String htmlContent = """
+            <!--
+            /**
+             * Activity table.
+             *
+             * @fragment activityTable
+             * @param rows {@code Map<String, List<Item>>} [optional=empty] Row map.
+             * Supports grouped entries.
+             * values: "active", "archived"
+             * @model view.sections[].items {@code List<Map<String, Item>>} [required] Section items.
+             * Rendered in display order.
+             */
+            -->
+            <section th:fragment="activityTable(rows)">Table</section>
+            """;
+
+        List<JavaDocAnalyzer.JavaDocInfo> result = analyzer.analyzeJavaDocFromHtml(htmlContent);
+
+        assertThat(result).singleElement()
+            .satisfies(docInfo -> {
+                assertThat(docInfo.getFragmentNameOptional()).contains("activityTable");
+                assertThat(docInfo.getParameters()).singleElement()
+                    .satisfies(parameter -> {
+                        assertThat(parameter.getName()).isEqualTo("rows");
+                        assertThat(parameter.getType()).isEqualTo("Map<String, List<Item>>");
+                        assertThat(parameter.getDefaultValueOptional()).contains("empty");
+                        assertThat(parameter.getDescription()).isEqualTo("Row map. Supports grouped entries");
+                        assertThat(parameter.getAllowedValues()).containsExactly("active", "archived");
+                    });
+                assertThat(docInfo.getModels()).singleElement()
+                    .satisfies(model -> {
+                        assertThat(model.getName()).isEqualTo("view.sections[].items");
+                        assertThat(model.getType()).isEqualTo("List<Map<String, Item>>");
+                        assertThat(model.getDescription()).isEqualTo("Section items. Rendered in display order.");
+                    });
+            });
+    }
+
+    @Test
     @DisplayName("複数コメントで複数行説明・許可値・デフォルト値・背景色を維持して解析できる")
     void shouldParseMultipleBlocksWithMultilineDescriptionsAllowedValuesDefaultsAndBackground() {
         // Given

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocTagParserTest.java
@@ -1,0 +1,75 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JavaDocTagParserTest {
+
+    private final JavaDocTagParser parser = new JavaDocTagParser();
+
+    @Test
+    void parse_shouldHandleGenericParamTypesDefaultMarkersAllowedValuesAndMultilineDescriptions() {
+        JavaDocTagParser.ParsedTags parsed = parser.parse("""
+            /**
+             * Table component.
+             * @param rows {@code Map<String, List<Item>>} [optional=empty] Row map.
+             * Supports grouped entries.
+             * values: "active", "archived"
+             */
+            """);
+
+        assertThat(parsed.parameters()).singleElement()
+            .satisfies(parameter -> {
+                assertThat(parameter.getName()).isEqualTo("rows");
+                assertThat(parameter.getType()).isEqualTo("Map<String, List<Item>>");
+                assertThat(parameter.isRequired()).isFalse();
+                assertThat(parameter.getDefaultValueOptional()).contains("empty");
+                assertThat(parameter.getDescription()).isEqualTo("Row map. Supports grouped entries");
+                assertThat(parameter.getAllowedValues()).containsExactly("active", "archived");
+            });
+    }
+
+    @Test
+    void parse_shouldHandleModelPathsGenericTypesAndMultilineDescriptions() {
+        JavaDocTagParser.ParsedTags parsed = parser.parse("""
+            /**
+             * Activity list.
+             * @model view.sections[].items {@code List<Map<String, Item>>} [required] Section items.
+             * Rendered in display order.
+             */
+            """);
+
+        assertThat(parsed.models()).singleElement()
+            .satisfies(model -> {
+                assertThat(model.getName()).isEqualTo("view.sections[].items");
+                assertThat(model.getType()).isEqualTo("List<Map<String, Item>>");
+                assertThat(model.isRequired()).isTrue();
+                assertThat(model.getDescription()).isEqualTo("Section items. Rendered in display order.");
+            });
+    }
+
+    @Test
+    void parse_shouldSkipIncompleteParamAndModelTagsWithoutDroppingOtherTags() {
+        JavaDocTagParser.ParsedTags parsed = parser.parse("""
+            /**
+             * Partial tags.
+             * @param incomplete
+             * @param label {@code String} [required] Label text
+             * @model broken.path {@code String}
+             * @model view.title {@code String} [optional=Untitled] Title text
+             * @fragment partialTags
+             */
+            """);
+
+        assertThat(parsed.parameters()).singleElement()
+            .extracting(JavaDocAnalyzer.ParameterInfo::getName)
+            .isEqualTo("label");
+        assertThat(parsed.models()).singleElement()
+            .satisfies(model -> {
+                assertThat(model.getName()).isEqualTo("view.title");
+                assertThat(model.getDefaultValueOptional()).contains("Untitled");
+            });
+        assertThat(parsed.fragmentName()).contains("partialTags");
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the large `@param` / `@model` JavaDoc field regexes with staged cursor parsing for tag name, identifier/path, `{@code ...}` type, required/optional marker/default, and description.
- Preserve fragment/background/allowed-values handling while avoiding the prior trailing `*/` slash leaking into multiline descriptions.
- Add focused `JavaDocTagParserTest` coverage and `JavaDocAnalyzerTest` integration coverage for generic Java types, defaults, allowed values, multiline descriptions, and incomplete tag skipping.

## Verification
- `./mvnw -q -Dtest=JavaDocTagParserTest,JavaDocAnalyzerTest test`
- `./mvnw -q -Dtest=JavaDocTagParserTest,JavaDocAnalyzerTest,JavaDocAnalyzerRealFileTest,RealJavaDocParsingTest,TypeInformationExtractorTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

Kanban: #501
Closes: N/A
