### PR TITLE
Add parser diagnostics carriers

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
@@ -4,39 +4,65 @@ import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class FragmentExpressionParser {
 
     public Optional<FragmentExpression> parse(String rawExpression) {
+        return parseWithDiagnostics(rawExpression).expression();
+    }
+
+    public FragmentExpressionParseResult parseWithDiagnostics(String rawExpression) {
         if (rawExpression == null || rawExpression.isBlank()) {
-            return Optional.empty();
+            return FragmentExpressionParseResult.empty(
+                ParserDiagnostic.warning("FRAGMENT_EXPRESSION_EMPTY", "Fragment expression is empty")
+            );
         }
         String expression = unwrapFragmentExpression(rawExpression.trim());
-        if (expression.isBlank()
-            || expression.startsWith("${")
-            || expression.startsWith("*{")
-            || expression.startsWith("#{")) {
-            return Optional.empty();
+        if (expression.isBlank()) {
+            return FragmentExpressionParseResult.empty(
+                ParserDiagnostic.warning("FRAGMENT_EXPRESSION_EMPTY", "Fragment expression is empty")
+            );
+        }
+        if (expression.startsWith("${") || expression.startsWith("*{") || expression.startsWith("#{")) {
+            return FragmentExpressionParseResult.empty(
+                ParserDiagnostic.warning(
+                    "FRAGMENT_EXPRESSION_DYNAMIC",
+                    "Dynamic fragment expression was skipped: " + rawExpression.trim()
+                )
+            );
         }
 
         int separatorIndex = findTopLevelFragmentSeparator(expression);
         if (separatorIndex <= 0 || separatorIndex >= expression.length() - 2) {
-            return Optional.empty();
+            return FragmentExpressionParseResult.empty(
+                ParserDiagnostic.warning(
+                    "FRAGMENT_EXPRESSION_MALFORMED",
+                    "Fragment expression is missing a valid template/fragment separator: " + rawExpression.trim()
+                )
+            );
         }
 
         String templatePath = normalizeTemplatePath(expression.substring(0, separatorIndex));
         Optional<FragmentSelector> selector = parseFragmentSelector(expression.substring(separatorIndex + 2));
         if (templatePath.isBlank() || selector.isEmpty()) {
-            return Optional.empty();
+            return FragmentExpressionParseResult.empty(
+                ParserDiagnostic.warning(
+                    "FRAGMENT_EXPRESSION_MALFORMED",
+                    "Fragment expression could not be parsed: " + rawExpression.trim()
+                )
+            );
         }
         FragmentSelector resolvedSelector = selector.orElseThrow();
-        return Optional.of(FragmentExpression.of(
-            templatePath,
-            resolvedSelector.name(),
-            resolvedSelector.arguments(),
-            resolvedSelector.hasArgumentList()
-        ));
+        return FragmentExpressionParseResult.success(
+            FragmentExpression.of(
+                templatePath,
+                resolvedSelector.name(),
+                resolvedSelector.arguments(),
+                resolvedSelector.hasArgumentList()
+            )
+        );
     }
 
     private String unwrapFragmentExpression(String rawExpression) {
@@ -128,6 +154,24 @@ public class FragmentExpressionParser {
     }
 
     private record FragmentSelector(String name, List<String> arguments, boolean hasArgumentList) {
+    }
+
+    public record FragmentExpressionParseResult(
+        Optional<FragmentExpression> expression,
+        List<ParserDiagnostic> diagnostics
+    ) {
+        public FragmentExpressionParseResult {
+            expression = Objects.requireNonNull(expression, "expression cannot be null");
+            diagnostics = List.copyOf(diagnostics);
+        }
+
+        private static FragmentExpressionParseResult success(FragmentExpression expression) {
+            return new FragmentExpressionParseResult(Optional.of(expression), List.of());
+        }
+
+        private static FragmentExpressionParseResult empty(ParserDiagnostic diagnostic) {
+            return new FragmentExpressionParseResult(Optional.empty(), List.of(diagnostic));
+        }
     }
 
     private static final class ScanState {

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/ParserDiagnostic.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/ParserDiagnostic.java
@@ -1,0 +1,15 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import java.util.Objects;
+
+public record ParserDiagnostic(String code, String message, int line, int column) {
+
+    public ParserDiagnostic {
+        code = Objects.requireNonNull(code, "code cannot be null");
+        message = Objects.requireNonNull(message, "message cannot be null");
+    }
+
+    public static ParserDiagnostic warning(String code, String message) {
+        return new ParserDiagnostic(code, message, -1, -1);
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
@@ -30,6 +30,67 @@ public class StructuredTemplateParser {
         return handler.toParsedTemplate();
     }
 
+    public TemplateParseResult parseWithDiagnostics(String html) {
+        Objects.requireNonNull(html, "html cannot be null");
+        try {
+            ParsedTemplate parsedTemplate = parse(html);
+            return new TemplateParseResult(parsedTemplate, diagnosticsFor(parsedTemplate));
+        } catch (IllegalArgumentException parseFailure) {
+            return new TemplateParseResult(
+                new ParsedTemplate(List.of(), List.of(), List.of()),
+                List.of(ParserDiagnostic.warning("TEMPLATE_MARKUP_MALFORMED", diagnosticMessage(parseFailure)))
+            );
+        }
+    }
+
+    private String diagnosticMessage(Exception failure) {
+        String message = failure.getMessage();
+        if (message == null || message.isBlank()) {
+            return failure.getClass().getSimpleName();
+        }
+        return message;
+    }
+
+    private List<ParserDiagnostic> diagnosticsFor(ParsedTemplate parsedTemplate) {
+        List<ParserDiagnostic> diagnostics = new ArrayList<>();
+        for (TemplateElement element : parsedTemplate.elements()) {
+            for (TemplateAttribute attribute : element.attributes()) {
+                if (isFragmentReferenceAttribute(attribute) && isDynamicSyntax(attribute.value())) {
+                    diagnostics.add(new ParserDiagnostic(
+                        "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED",
+                        "Dynamic fragment reference was skipped in `" + attribute.name() + "`",
+                        attribute.line(),
+                        attribute.column()
+                    ));
+                }
+            }
+        }
+        return diagnostics;
+    }
+
+    private boolean isFragmentReferenceAttribute(TemplateAttribute attribute) {
+        String normalized = attribute.name().toLowerCase(Locale.ROOT);
+        return attribute.hasValue()
+            && (normalized.equals("th:replace")
+            || normalized.equals("th:insert")
+            || normalized.equals("th:include")
+            || normalized.equals("data-th-replace")
+            || normalized.equals("data-th-insert")
+            || normalized.equals("data-th-include"));
+    }
+
+    private boolean isDynamicSyntax(String value) {
+        String trimmed = value.trim();
+        return trimmed.startsWith("${") || trimmed.startsWith("*{") || trimmed.startsWith("#{");
+    }
+
+    public record TemplateParseResult(ParsedTemplate parsedTemplate, List<ParserDiagnostic> diagnostics) {
+        public TemplateParseResult {
+            parsedTemplate = Objects.requireNonNull(parsedTemplate, "parsedTemplate cannot be null");
+            diagnostics = List.copyOf(diagnostics);
+        }
+    }
+
     public record ParsedTemplate(List<TemplateElement> elements, List<TemplateText> textNodes, List<TemplateComment> comments) {
         public ParsedTemplate {
             elements = List.copyOf(elements);

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
 import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 final class JavaDocExampleParser {
@@ -26,21 +26,33 @@ final class JavaDocExampleParser {
     }
 
     List<JavaDocAnalyzer.ExampleInfo> parse(String javadocContent) {
+        return parseWithDiagnostics(javadocContent).examples();
+    }
+
+    ExampleParseResult parseWithDiagnostics(String javadocContent) {
         List<JavaDocAnalyzer.ExampleInfo> examples = new ArrayList<>();
+        List<ParserDiagnostic> diagnostics = new ArrayList<>();
 
         for (String exampleMarkup : extractExampleMarkup(javadocContent)) {
-            StructuredTemplateParser.ParsedTemplate parsedTemplate = parseExampleMarkup(exampleMarkup);
+            StructuredTemplateParser.TemplateParseResult parseResult = parseExampleMarkup(exampleMarkup);
+            diagnostics.addAll(parseResult.diagnostics());
+            StructuredTemplateParser.ParsedTemplate parsedTemplate = parseResult.parsedTemplate();
             for (StructuredTemplateParser.TemplateElement element : parsedTemplate.elements()) {
                 for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
                     String normalizedName = attribute.name().toLowerCase(java.util.Locale.ROOT);
                     if (!attribute.hasValue() || !EXAMPLE_REPLACE_ATTRIBUTES.contains(normalizedName)) {
                         continue;
                     }
-                    parseExampleReference(attribute.value()).ifPresent(examples::add);
+                    FragmentExpressionParser.FragmentExpressionParseResult referenceResult =
+                        fragmentExpressionParser.parseWithDiagnostics(attribute.value());
+                    diagnostics.addAll(referenceResult.diagnostics());
+                    referenceResult.expression()
+                        .map(this::toExampleInfo)
+                        .ifPresent(examples::add);
                 }
             }
         }
-        return examples;
+        return new ExampleParseResult(examples, diagnostics);
     }
 
     private List<String> extractExampleMarkup(String javadocContent) {
@@ -104,18 +116,24 @@ final class JavaDocExampleParser {
         }
     }
 
-    private StructuredTemplateParser.ParsedTemplate parseExampleMarkup(String exampleMarkup) {
+    private StructuredTemplateParser.TemplateParseResult parseExampleMarkup(String exampleMarkup) {
         try {
-            return templateParser.parse(exampleMarkup);
+            return templateParser.parseWithDiagnostics(exampleMarkup);
         } catch (IllegalArgumentException parseFailure) {
             logger.debug("Failed to parse @example markup: {}", exampleMarkup, parseFailure);
-            return new StructuredTemplateParser.ParsedTemplate(List.of(), List.of(), List.of());
+            return new StructuredTemplateParser.TemplateParseResult(
+                new StructuredTemplateParser.ParsedTemplate(List.of(), List.of(), List.of()),
+                List.of(ParserDiagnostic.warning("JAVADOC_EXAMPLE_MARKUP_MALFORMED", diagnosticMessage(parseFailure)))
+            );
         }
     }
 
-    private Optional<JavaDocAnalyzer.ExampleInfo> parseExampleReference(String rawReference) {
-        return fragmentExpressionParser.parse(rawReference)
-            .map(this::toExampleInfo);
+    private String diagnosticMessage(Exception failure) {
+        String message = failure.getMessage();
+        if (message == null || message.isBlank()) {
+            return failure.getClass().getSimpleName();
+        }
+        return message;
     }
 
     private JavaDocAnalyzer.ExampleInfo toExampleInfo(FragmentExpression expression) {
@@ -124,5 +142,12 @@ final class JavaDocExampleParser {
             expression.fragmentName(),
             expression.arguments()
         );
+    }
+
+    record ExampleParseResult(List<JavaDocAnalyzer.ExampleInfo> examples, List<ParserDiagnostic> diagnostics) {
+        ExampleParseResult {
+            examples = List.copyOf(examples);
+            diagnostics = List.copyOf(diagnostics);
+        }
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
@@ -49,4 +49,34 @@ class FragmentExpressionParserTest {
         assertThat(parser.parse("~{components/card :: card(label=${view.title)}")).isEmpty();
         assertThat(parser.parse("~{${dynamicPath} :: card()}")).isEmpty();
     }
+
+    @Test
+    void parseWithDiagnostics_shouldReturnNoWarningsForValidExpression() {
+        FragmentExpressionParser.FragmentExpressionParseResult result =
+            parser.parseWithDiagnostics("~{components/card :: card(title='Hello')}");
+
+        assertThat(result.expression()).isPresent();
+        assertThat(result.diagnostics()).isEmpty();
+    }
+
+    @Test
+    void parseWithDiagnostics_shouldWarnForMalformedAndDynamicExpressions() {
+        FragmentExpressionParser.FragmentExpressionParseResult malformed =
+            parser.parseWithDiagnostics("~{components/card}");
+        FragmentExpressionParser.FragmentExpressionParseResult dynamic =
+            parser.parseWithDiagnostics("${dynamicRef}");
+
+        assertThat(malformed.expression()).isEmpty();
+        assertThat(malformed.diagnostics()).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_EXPRESSION_MALFORMED");
+                assertThat(diagnostic.message()).contains("components/card");
+            });
+        assertThat(dynamic.expression()).isEmpty();
+        assertThat(dynamic.diagnostics()).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_EXPRESSION_DYNAMIC");
+                assertThat(diagnostic.message()).contains("dynamicRef");
+            });
+    }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParserTest.java
@@ -207,6 +207,39 @@ class StructuredTemplateParserTest {
             );
     }
 
+    @Test
+    void parseWithDiagnostics_shouldWarnForDynamicFragmentReferences() {
+        String html = """
+            <section>
+              <div th:replace="${dynamicReference}"></div>
+              <div data-th-insert="~{components/card :: card()}"></div>
+            </section>
+            """;
+
+        StructuredTemplateParser.TemplateParseResult result = parser.parseWithDiagnostics(html);
+
+        assertThat(result.parsedTemplate().elements())
+            .extracting(StructuredTemplateParser.TemplateElement::name)
+            .containsExactly("section", "div", "div");
+        assertThat(result.diagnostics()).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED");
+                assertThat(diagnostic.message()).contains("th:replace");
+                assertThat(diagnostic.line()).isGreaterThan(0);
+                assertThat(diagnostic.column()).isGreaterThan(0);
+            });
+    }
+
+    @Test
+    void parseWithDiagnostics_shouldReturnNoWarningsForStaticMarkup() {
+        StructuredTemplateParser.TemplateParseResult result = parser.parseWithDiagnostics("""
+            <section th:replace="~{components/card :: card()}">Card</section>
+            """);
+
+        assertThat(result.parsedTemplate().elements()).hasSize(1);
+        assertThat(result.diagnostics()).isEmpty();
+    }
+
     private static java.util.List<String> fragmentDefinitions(StructuredTemplateParser.ParsedTemplate parsed) {
         return parsed.elements().stream()
             .flatMap(element -> element.attributeValue("th:fragment").stream())

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParserTest.java
@@ -1,0 +1,49 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
+import org.junit.jupiter.api.Test;
+
+class JavaDocExampleParserTest {
+
+    private final JavaDocExampleParser parser = new JavaDocExampleParser(new StructuredTemplateParser());
+
+    @Test
+    void parseWithDiagnostics_shouldReturnNoWarningsForValidExamples() {
+        JavaDocExampleParser.ExampleParseResult result = parser.parseWithDiagnostics("""
+            /**
+             * Valid example.
+             * @example <div th:replace="~{components/card :: card(title='Hello')}"></div>
+             */
+            """);
+
+        assertThat(result.examples()).singleElement()
+            .satisfies(example -> {
+                assertThat(example.getTemplatePath()).isEqualTo("components/card");
+                assertThat(example.getFragmentName()).isEqualTo("card");
+                assertThat(example.getArguments()).containsExactly("title='Hello'");
+            });
+        assertThat(result.diagnostics()).isEmpty();
+    }
+
+    @Test
+    void parseWithDiagnostics_shouldWarnForInvalidExampleReferences() {
+        JavaDocExampleParser.ExampleParseResult result = parser.parseWithDiagnostics("""
+            /**
+             * Invalid example.
+             * @example <div th:replace="~{components/card}"></div>
+             * @example <div data-th-replace="${dynamicReference}"></div>
+             */
+            """);
+
+        assertThat(result.examples()).isEmpty();
+        assertThat(result.diagnostics())
+            .extracting(diagnostic -> diagnostic.code())
+            .containsExactly(
+                "FRAGMENT_EXPRESSION_MALFORMED",
+                "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED",
+                "FRAGMENT_EXPRESSION_DYNAMIC"
+            );
+    }
+}


### PR DESCRIPTION
## Summary
- Add non-breaking parser diagnostics carriers through `ParserDiagnostic` and `parseWithDiagnostics(...)` methods.
- Preserve existing `parse(...)` behavior for fragment expressions, structured templates, and JavaDoc examples.
- Add warnings for malformed fragment expressions, dynamic fragment syntax, invalid JavaDoc example references, and skipped dynamic template fragment references.
- Add no-warning success-path tests and warning-content assertions.

## Verification
- `./mvnw -q -Dtest=FragmentExpressionParserTest,StructuredTemplateParserTest,JavaDocExampleParserTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

Kanban: #502
Closes: N/A
