### PR TITLE
Evaluate external HTML parser adapter

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -130,3 +130,14 @@ list 内の値を記述する場合は `@model` path に `[]` を使います。
 ```
 
 構文サポートを追加する場合は、広い E2E assertion より parser-owned test を優先してください。E2E はユーザー向け preview が描画できることを確認し、unit/integration test で解析契約を定義します。
+
+## 外部パーサ評価
+
+`HtmlParserAdapterComparisonTest` は、外部 HTML パーサを Thymeleaflet の parser corpus に対して評価するための比較 spike です。現在の候補は jsoup で、依存は test scope のみに限定しています。このテストハーネスは regression corpus を `StructuredTemplateParser` と候補アダプタの両方で解析し、次の契約を比較します。
+
+- `th:*`、`data-th-*`、quote 付き fragment selector、複数行値、literal `>`、boolean 属性に隣接する属性を含め、Thymeleaf 属性名と値を保持できること。
+- fragment 宣言を source order で発見できること。
+- browser tolerant な malformed HTML でも、fragment と model 抽出に必要な範囲を解析できること。
+- subtree 抽出で sibling fragment を分離できること。
+
+推奨方針: production parser は Attoparser ベースの `StructuredTemplateParser` を維持します。Attoparser は Thymeleaf 互換の HTML 解析を使え、diagnostics で利用する source line/column も提供できます。jsoup は corpus 比較ツールや fallback 候補の調査には有用ですが、document tree を正規化し、現行 diagnostics が必要とする source position を提供しません。将来の adapter が corpus 上で同等性を示し、source location と Thymeleaf 固有挙動の扱いを解決するまでは production parser を置き換えません。

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -130,3 +130,14 @@ Add parser regressions when a defect involves template attributes, JavaDoc examp
 ```
 
 When adding syntax support, prefer parser-owned tests over broad end-to-end assertions. E2E should prove the user-facing preview still renders; unit and integration tests should define the parsing contract.
+
+## External Parser Evaluation
+
+`HtmlParserAdapterComparisonTest` is the comparison spike for evaluating external HTML parsers against the Thymeleaflet parser corpus. The current candidate is jsoup, added only as a test-scoped dependency. The test harness runs the regression corpus through both `StructuredTemplateParser` and the candidate adapter, then compares these contract points:
+
+- Thymeleaf attribute names and values are preserved, including `th:*`, `data-th-*`, quoted fragment selectors, multiline values, literal `>` characters, and boolean-adjacent attributes.
+- Fragment declarations remain discoverable in source order.
+- Browser-tolerated malformed HTML remains parseable enough for fragment and model extraction.
+- Subtree extraction can keep sibling fragments isolated.
+
+Recommendation: keep `StructuredTemplateParser` on Attoparser for production parsing. Attoparser uses Thymeleaf-compatible HTML parsing and exposes source line/column positions used by diagnostics. jsoup is useful as a corpus comparison tool and fallback research candidate, but it normalizes the document tree and does not provide the source positions required by current diagnostics. Do not replace the production parser until a future adapter proves equivalent on the corpus and provides a plan for source locations and Thymeleaf-specific parsing behavior.

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.22.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/HtmlParserAdapterComparisonTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/HtmlParserAdapterComparisonTest.java
@@ -1,0 +1,230 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.wamukat.thymeleaflet.testsupport.FixtureResources;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class HtmlParserAdapterComparisonTest {
+
+    private final StructuredTemplateParser structuredParser = new StructuredTemplateParser();
+    private final JsoupTemplateParserAdapter jsoupAdapter = new JsoupTemplateParserAdapter();
+
+    @Test
+    void jsoupAdapter_shouldPreserveThymeleafAttributesAcrossRegressionCorpus() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
+        CandidateTemplate candidate = jsoupAdapter.parse(html);
+
+        assertThat(candidate.thymeleafAttributes())
+            .containsAll(currentThymeleafAttributes(current));
+        assertThat(candidate.thymeleafAttributes())
+            .contains(
+                "data-th-each=item : ${view.items}",
+                "th:replace=~{'regression/parser-corpus' :: quotedTarget(label=${view.label})}",
+                "data-th-text=${view.malformed.label}",
+                "th:include=~{regression/parser-corpus :: nestedChild(title='Included > Nested')}",
+                "data-th-include=~{regression/parser-corpus :: nestedChild(title=${view.mixed.title})}",
+                "data-th-value=${view.mixed.title}"
+            );
+    }
+
+    @Test
+    void jsoupAdapter_shouldKeepFragmentDeclarationOrderStableForCorpus() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
+        CandidateTemplate candidate = jsoupAdapter.parse(html);
+
+        assertThat(candidate.fragmentDefinitions())
+            .containsSequence(currentFragmentDefinitions(current));
+    }
+
+    @Test
+    void jsoupAdapter_shouldTolerateMalformedHtmlButNotReplaceCurrentParserCapabilities() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
+        CandidateTemplate candidate = jsoupAdapter.parse(html);
+
+        assertThat(currentElement(current, "malformedHtmlShell").attributeValue("th:fragment"))
+            .hasValue("malformedHtmlShell");
+        assertThat(candidate.element("malformedHtmlShell").flatMap(element -> element.attributeValue("th:fragment")))
+            .hasValue("malformedHtmlShell");
+        assertThat(candidate.thymeleafAttributes())
+            .contains("data-th-text=${view.malformed.label}");
+
+        assertThat(current.elements())
+            .allSatisfy(element -> assertThat(element.line()).isPositive());
+        assertThat(candidate.hasSourcePositions()).isFalse();
+    }
+
+    @Test
+    void jsoupAdapter_shouldRespectSiblingSubtreeBoundariesForCandidateEvaluation() {
+        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+
+        CandidateTemplate candidate = jsoupAdapter.parse(html);
+
+        assertThat(attributeValues(candidate.subtree(candidate.element("siblingBoundaryA").orElseThrow()), "th:text"))
+            .contains("${view.boundary.a}")
+            .doesNotContain("${view.boundary.b}");
+        assertThat(attributeValues(candidate.subtree(candidate.element("siblingBoundaryB").orElseThrow()), "th:text"))
+            .contains("${view.boundary.b}")
+            .doesNotContain("${view.boundary.a}");
+    }
+
+    private static List<String> currentThymeleafAttributes(StructuredTemplateParser.ParsedTemplate parsed) {
+        return parsed.elements().stream()
+            .flatMap(element -> element.thymeleafAttributes().stream())
+            .map(attribute -> attribute.name() + "=" + attribute.value())
+            .toList();
+    }
+
+    private static List<String> currentFragmentDefinitions(StructuredTemplateParser.ParsedTemplate parsed) {
+        return parsed.elements().stream()
+            .flatMap(element -> element.attributeValue("th:fragment").stream())
+            .toList();
+    }
+
+    private static StructuredTemplateParser.TemplateElement currentElement(
+        StructuredTemplateParser.ParsedTemplate parsed,
+        String fragmentName
+    ) {
+        return parsed.elements().stream()
+            .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private static List<String> attributeValues(List<CandidateElement> elements, String attributeName) {
+        return elements.stream()
+            .flatMap(element -> element.attributeValue(attributeName).stream())
+            .toList();
+    }
+
+    private static final class JsoupTemplateParserAdapter {
+
+        CandidateTemplate parse(String html) {
+            Objects.requireNonNull(html, "html cannot be null");
+            Element root = Jsoup.parse(html, "", Parser.htmlParser());
+            List<CandidateElement> elements = new ArrayList<>();
+            collect(root, -1, 0, elements);
+            return new CandidateTemplate(elements);
+        }
+
+        private static void collect(Element element, int parentIndex, int depth, List<CandidateElement> elements) {
+            int index = elements.size();
+            Map<String, String> attributes = element.attributes().asList().stream()
+                .collect(Collectors.toMap(
+                    Attribute::getKey,
+                    Attribute::getValue,
+                    (first, second) -> first
+                ));
+            elements.add(new CandidateElement(element.normalName(), attributes, index, parentIndex, depth));
+            for (Element child : element.children()) {
+                collect(child, index, depth + 1, elements);
+            }
+        }
+    }
+
+    private record CandidateTemplate(List<CandidateElement> elements) {
+        CandidateTemplate {
+            elements = List.copyOf(elements);
+        }
+
+        List<String> thymeleafAttributes() {
+            return elements.stream()
+                .flatMap(element -> element.thymeleafAttributes().stream())
+                .toList();
+        }
+
+        List<String> fragmentDefinitions() {
+            return elements.stream()
+                .flatMap(element -> element.attributeValue("th:fragment").stream())
+                .toList();
+        }
+
+        Optional<CandidateElement> element(String fragmentName) {
+            return elements.stream()
+                .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
+                .findFirst();
+        }
+
+        List<CandidateElement> subtree(CandidateElement root) {
+            Map<Integer, CandidateElement> byIndex = elements.stream()
+                .collect(Collectors.toUnmodifiableMap(CandidateElement::index, element -> element));
+            Predicate<CandidateElement> isRootOrDescendant =
+                element -> element.index() == root.index() || isDescendantOf(element, root.index(), byIndex);
+            return elements.stream()
+                .filter(isRootOrDescendant)
+                .toList();
+        }
+
+        boolean hasSourcePositions() {
+            return false;
+        }
+
+        private static boolean isDescendantOf(
+            CandidateElement candidate,
+            int rootIndex,
+            Map<Integer, CandidateElement> byIndex
+        ) {
+            int parentIndex = candidate.parentIndex();
+            while (parentIndex >= 0) {
+                if (parentIndex == rootIndex) {
+                    return true;
+                }
+                CandidateElement parent = byIndex.get(parentIndex);
+                if (parent == null) {
+                    return false;
+                }
+                parentIndex = parent.parentIndex();
+            }
+            return false;
+        }
+    }
+
+    private record CandidateElement(
+        String name,
+        Map<String, String> attributes,
+        int index,
+        int parentIndex,
+        int depth
+    ) {
+        CandidateElement {
+            name = name.trim();
+            attributes = Map.copyOf(attributes);
+        }
+
+        Optional<String> attributeValue(String attributeName) {
+            Objects.requireNonNull(attributeName, "attributeName cannot be null");
+            return Optional.ofNullable(attributes.get(attributeName));
+        }
+
+        List<String> thymeleafAttributes() {
+            return attributes.entrySet().stream()
+                .filter(entry -> isThymeleafAttribute(entry.getKey()))
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .toList();
+        }
+
+        private static boolean isThymeleafAttribute(String name) {
+            String normalized = name.toLowerCase(Locale.ROOT);
+            return normalized.startsWith("th:") || normalized.startsWith("data-th-");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a test-scoped jsoup comparison spike for the parser regression corpus
- Compare Thymeleaf attribute preservation, fragment order, malformed HTML tolerance, and sibling subtree boundaries
- Document the external parser evaluation and recommendation in English and Japanese template parsing docs

## Verification

- `./mvnw -q -Dtest=HtmlParserAdapterComparisonTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

Closes Kanban #503
