### PR TITLE
Use structured attributes for unsafe fragment insertion checks

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentRenderingService.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * フラグメント動的レンダリング処理専用サービス
@@ -60,6 +59,8 @@ public class FragmentRenderingService {
 
     private final StoryJavaTimeValueCoercionService storyJavaTimeValueCoercionService;
 
+    private final UnsafeFragmentInsertionDetector unsafeFragmentInsertionDetector;
+
     public FragmentRenderingService(
         ValidationUseCase validationUseCase,
         StoryRetrievalUseCase storyRetrievalUseCase,
@@ -82,6 +83,7 @@ public class FragmentRenderingService {
         this.fragmentModelInferenceService = fragmentModelInferenceService;
         this.javaDocLookupService = javaDocLookupService;
         this.storyJavaTimeValueCoercionService = storyJavaTimeValueCoercionService;
+        this.unsafeFragmentInsertionDetector = new UnsafeFragmentInsertionDetector();
     }
 
     /**
@@ -416,25 +418,7 @@ public class FragmentRenderingService {
             return Optional.empty();
         }
 
-        for (Map.Entry<String, Object> entry : mergedParameters.entrySet()) {
-            Object value = entry.getValue();
-            if (!(value instanceof String stringValue)) {
-                continue;
-            }
-            String trimmedValue = stringValue.trim();
-            if (trimmedValue.startsWith("~{") && trimmedValue.endsWith("}")) {
-                continue;
-            }
-
-            String parameterName = entry.getKey();
-            Pattern unsafeInsertionPattern = Pattern.compile(
-                "th:(?:replace|insert)\\s*=\\s*['\"]\\$\\{\\s*" + Pattern.quote(parameterName) + "\\s*}['\"]"
-            );
-            if (unsafeInsertionPattern.matcher(templateSource).find()) {
-                return Optional.of(parameterName);
-            }
-        }
-        return Optional.empty();
+        return unsafeFragmentInsertionDetector.findUnsafeParameter(templateSource, mergedParameters);
     }
 
     private String readTemplateSource(String templatePath) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetector.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetector.java
@@ -1,0 +1,71 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+final class UnsafeFragmentInsertionDetector {
+
+    private static final Set<String> INSERTION_ATTRIBUTES = Set.of(
+        "th:replace",
+        "th:insert",
+        "data-th-replace",
+        "data-th-insert"
+    );
+
+    private final StructuredTemplateParser templateParser;
+
+    UnsafeFragmentInsertionDetector() {
+        this(new StructuredTemplateParser());
+    }
+
+    UnsafeFragmentInsertionDetector(StructuredTemplateParser templateParser) {
+        this.templateParser = templateParser;
+    }
+
+    Optional<String> findUnsafeParameter(String templateSource, Map<String, Object> mergedParameters) {
+        StructuredTemplateParser.ParsedTemplate parsedTemplate = templateParser
+            .parseWithDiagnostics(templateSource)
+            .parsedTemplate();
+        if (parsedTemplate.elements().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return mergedParameters.entrySet().stream()
+            .filter(entry -> isUnsafeCandidateValue(entry.getValue()))
+            .map(Map.Entry::getKey)
+            .filter(parameterName -> hasDynamicInsertionAttribute(parsedTemplate, parameterName))
+            .findFirst();
+    }
+
+    private boolean isUnsafeCandidateValue(Object value) {
+        if (!(value instanceof String stringValue)) {
+            return false;
+        }
+        String trimmedValue = stringValue.trim();
+        return !(trimmedValue.startsWith("~{") && trimmedValue.endsWith("}"));
+    }
+
+    private boolean hasDynamicInsertionAttribute(
+        StructuredTemplateParser.ParsedTemplate parsedTemplate,
+        String parameterName
+    ) {
+        return parsedTemplate.elements().stream()
+            .flatMap(element -> element.attributes().stream())
+            .filter(attribute -> attribute.hasValue())
+            .filter(attribute -> INSERTION_ATTRIBUTES.contains(attribute.name().toLowerCase(Locale.ROOT)))
+            .anyMatch(attribute -> isParameterExpression(attribute.value(), parameterName));
+    }
+
+    private boolean isParameterExpression(String attributeValue, String parameterName) {
+        String trimmedValue = attributeValue.trim();
+        if (!trimmedValue.startsWith("${") || !trimmedValue.endsWith("}")) {
+            return false;
+        }
+        String expressionBody = trimmedValue.substring(2, trimmedValue.length() - 1).trim();
+        return expressionBody.equals(parameterName);
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/controller/ThymeleafletRenderingExceptionHandlerIntegrationTest.java
@@ -62,6 +62,26 @@ class ThymeleafletRenderingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    @DisplayName("data-th-insert に通常文字列が渡された場合はエラーUIへフォールバックする")
+    void shouldFallbackToErrorFragmentOnInvalidDataThFragmentExpression() throws Exception {
+        String body = mockMvc.perform(get("/thymeleaflet/test.unsafe-fragment/dataUnsafe/default/render")
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertTrue(body.contains("Preview error"),
+            "テンプレート例外時にプレビューエラー表示へフォールバックすること");
+        assertTrue(
+            body.contains("th:replace/th:insert")
+                || body.contains("thymeleaflet.error.message.invalidFragmentExpression"),
+            "原因ヒント付きメッセージが表示されること");
+        assertFalse(body.contains("Whitelabel Error Page"),
+            "ホストアプリのデフォルトエラーページに遷移しないこと");
+    }
+
+    @Test
     @DisplayName("JavaDoc @param の java.time 型に基づいて story parameters を変換して描画する")
     void shouldRenderJavaTimeParameterValuesFromStoryYaml() throws Exception {
         String body = mockMvc.perform(get("/thymeleaflet/test.java-time-story/detailHeader/default/render")

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetectorTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetectorTest.java
@@ -1,0 +1,67 @@
+package io.github.wamukat.thymeleaflet.infrastructure.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UnsafeFragmentInsertionDetectorTest {
+
+    private final UnsafeFragmentInsertionDetector detector = new UnsafeFragmentInsertionDetector();
+
+    @Test
+    void findUnsafeParameter_shouldDetectMultilineThReplaceExpression() {
+        String html = """
+            <section th:fragment="shell(body)">
+              <th:block
+                  th:replace="${
+                    body
+                  }">
+              </th:block>
+            </section>
+            """;
+
+        assertThat(detector.findUnsafeParameter(html, Map.of("body", "components/card :: card")))
+            .hasValue("body");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"th:replace", "th:insert", "data-th-replace", "data-th-insert"})
+    void findUnsafeParameter_shouldDetectInsertionAttributes(String attributeName) {
+        String html = """
+            <section th:fragment="shell(content)">
+              <div %s='${ content }'></div>
+            </section>
+            """.formatted(attributeName);
+
+        assertThat(detector.findUnsafeParameter(html, Map.of("content", "components/card :: card")))
+            .hasValue("content");
+    }
+
+    @Test
+    void findUnsafeParameter_shouldIgnoreSafeLiteralFragmentExpressionValues() {
+        String html = """
+            <section th:fragment="shell(body)">
+              <th:block th:replace="${body}"></th:block>
+            </section>
+            """;
+
+        assertThat(detector.findUnsafeParameter(html, Map.of("body", "~{components/card :: card()}")))
+            .isEmpty();
+    }
+
+    @Test
+    void findUnsafeParameter_shouldIgnoreNonMatchingAndNonStringParameters() {
+        String html = """
+            <section th:fragment="shell(body)">
+              <th:block th:replace="${body}"></th:block>
+            </section>
+            """;
+
+        assertThat(detector.findUnsafeParameter(html, Map.of("body", 1, "other", "plain text")))
+            .isEmpty();
+    }
+}

--- a/src/test/resources/META-INF/thymeleaflet/stories/test/unsafe-fragment.stories.yml
+++ b/src/test/resources/META-INF/thymeleaflet/stories/test/unsafe-fragment.stories.yml
@@ -11,3 +11,11 @@ storyGroups:
         title: Default
         parameters:
           body: value
+  dataUnsafe:
+    title: Data Unsafe
+    description: Unsafe data-th-insert parameter case
+    stories:
+      - name: default
+        title: Default
+        parameters:
+          content: value

--- a/src/test/resources/templates/test/unsafe-fragment.html
+++ b/src/test/resources/templates/test/unsafe-fragment.html
@@ -4,5 +4,12 @@
 <th:block th:fragment="unsafe(body)">
     <th:block th:replace="${body}"></th:block>
 </th:block>
+<th:block th:fragment="dataUnsafe(content)">
+    <div
+        data-th-insert="${
+          content
+        }">
+    </div>
+</th:block>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- replace unsafe fragment insertion checks with StructuredTemplateParser-backed attribute detection
- cover th:replace/th:insert/data-th-replace/data-th-insert and multiline parameter expressions
- add rendering integration coverage for data-th-insert unsafe fallback

Closes #507

## Verification

- ./mvnw -q -Dtest=UnsafeFragmentInsertionDetectorTest test
- ./mvnw -q -Dtest=ThymeleafletRenderingExceptionHandlerIntegrationTest#shouldFallbackToErrorFragmentOnInvalidDataThFragmentExpression test
- ./mvnw -q -Dtest=UnsafeFragmentInsertionDetectorTest,ThymeleafletRenderingExceptionHandlerIntegrationTest test
- npm run test:workflow
- ./mvnw test -q
- npm run test:e2e:local
- git diff --check
