### PR TITLE
Extract top-level syntax scanner

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 public class FragmentExpressionParser {
 
+    private final TopLevelSyntaxScanner topLevelSyntaxScanner = new TopLevelSyntaxScanner();
+
     public Optional<FragmentExpression> parse(String rawExpression) {
         return parseWithDiagnostics(rawExpression).expression();
     }
@@ -73,16 +75,7 @@ public class FragmentExpressionParser {
     }
 
     private int findTopLevelFragmentSeparator(String expression) {
-        ScanState state = new ScanState();
-        for (int index = 0; index < expression.length() - 1; index++) {
-            state.accept(expression.charAt(index));
-            if (!state.isInsideNestedSyntax()
-                && expression.charAt(index) == ':'
-                && expression.charAt(index + 1) == ':') {
-                return index;
-            }
-        }
-        return -1;
+        return topLevelSyntaxScanner.findFirst(expression, "::").orElse(-1);
     }
 
     private String normalizeTemplatePath(String rawTemplatePath) {
@@ -119,21 +112,11 @@ public class FragmentExpressionParser {
 
     private Optional<List<String>> splitTopLevel(String value, char separator) {
         List<String> segments = new ArrayList<>();
-        ScanState state = new ScanState();
-        int segmentStart = 0;
-
-        for (int index = 0; index < value.length(); index++) {
-            char current = value.charAt(index);
-            state.accept(current);
-            if (!state.isInsideNestedSyntax() && current == separator) {
-                addSegment(segments, value.substring(segmentStart, index));
-                segmentStart = index + 1;
-            }
-        }
-        if (!state.isBalanced()) {
+        TopLevelSyntaxScanner.SplitResult splitResult = topLevelSyntaxScanner.split(value, separator);
+        if (!splitResult.isBalanced()) {
             return Optional.empty();
         }
-        addSegment(segments, value.substring(segmentStart));
+        splitResult.segments().forEach(segment -> addSegment(segments, segment));
         return Optional.of(segments);
     }
 
@@ -174,49 +157,4 @@ public class FragmentExpressionParser {
         }
     }
 
-    private static final class ScanState {
-        private int depthParen;
-        private int depthBracket;
-        private int depthBrace;
-        private boolean inSingleQuote;
-        private boolean inDoubleQuote;
-        private char previous;
-
-        private void accept(char current) {
-            if (current == '\'' && !inDoubleQuote && previous != '\\') {
-                inSingleQuote = !inSingleQuote;
-                previous = current;
-                return;
-            }
-            if (current == '"' && !inSingleQuote && previous != '\\') {
-                inDoubleQuote = !inDoubleQuote;
-                previous = current;
-                return;
-            }
-            if (!inSingleQuote && !inDoubleQuote) {
-                if (current == '(') {
-                    depthParen++;
-                } else if (current == ')' && depthParen > 0) {
-                    depthParen--;
-                } else if (current == '[') {
-                    depthBracket++;
-                } else if (current == ']' && depthBracket > 0) {
-                    depthBracket--;
-                } else if (current == '{') {
-                    depthBrace++;
-                } else if (current == '}' && depthBrace > 0) {
-                    depthBrace--;
-                }
-            }
-            previous = current;
-        }
-
-        private boolean isInsideNestedSyntax() {
-            return inSingleQuote || inDoubleQuote || depthParen > 0 || depthBracket > 0 || depthBrace > 0;
-        }
-
-        private boolean isBalanced() {
-            return !inSingleQuote && !inDoubleQuote && depthParen == 0 && depthBracket == 0 && depthBrace == 0;
-        }
-    }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TopLevelSyntaxScanner.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TopLevelSyntaxScanner.java
@@ -1,0 +1,109 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/**
+ * Tracks quotes and nested Thymeleaf expression syntax while scanning for top-level tokens.
+ */
+public final class TopLevelSyntaxScanner {
+
+    public OptionalInt findFirst(String value, String token) {
+        return findFirst(value, token, 0, value.length());
+    }
+
+    public OptionalInt findFirst(String value, String token, int startInclusive, int endExclusive) {
+        Objects.requireNonNull(value, "value cannot be null");
+        Objects.requireNonNull(token, "token cannot be null");
+        if (token.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        if (startInclusive < 0 || endExclusive > value.length() || startInclusive > endExclusive) {
+            throw new IllegalArgumentException("Invalid scan bounds");
+        }
+
+        ScanState state = new ScanState();
+        for (int index = startInclusive; index < endExclusive; index++) {
+            if (!state.isInsideNestedSyntax()
+                && index + token.length() <= endExclusive
+                && value.startsWith(token, index)) {
+                return OptionalInt.of(index);
+            }
+            state.accept(value.charAt(index));
+        }
+        return OptionalInt.empty();
+    }
+
+    public SplitResult split(String value, char separator) {
+        Objects.requireNonNull(value, "value cannot be null");
+        List<String> segments = new ArrayList<>();
+        ScanState state = new ScanState();
+        int segmentStart = 0;
+
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (!state.isInsideNestedSyntax() && current == separator) {
+                segments.add(value.substring(segmentStart, index));
+                segmentStart = index + 1;
+                continue;
+            }
+            state.accept(current);
+        }
+        segments.add(value.substring(segmentStart));
+        return new SplitResult(segments, state.isBalanced());
+    }
+
+    public record SplitResult(List<String> segments, boolean isBalanced) {
+        public SplitResult {
+            segments = List.copyOf(segments);
+        }
+    }
+
+    private static final class ScanState {
+        private int depthParen;
+        private int depthBracket;
+        private int depthBrace;
+        private boolean inSingleQuote;
+        private boolean inDoubleQuote;
+        private char previous;
+
+        private void accept(char current) {
+            if (current == '\'' && !inDoubleQuote && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+                previous = current;
+                return;
+            }
+            if (current == '"' && !inSingleQuote && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+                previous = current;
+                return;
+            }
+            if (!inSingleQuote && !inDoubleQuote) {
+                if (current == '(') {
+                    depthParen++;
+                } else if (current == ')' && depthParen > 0) {
+                    depthParen--;
+                } else if (current == '[') {
+                    depthBracket++;
+                } else if (current == ']' && depthBracket > 0) {
+                    depthBracket--;
+                } else if (current == '{') {
+                    depthBrace++;
+                } else if (current == '}' && depthBrace > 0) {
+                    depthBrace--;
+                }
+            }
+            previous = current;
+        }
+
+        private boolean isInsideNestedSyntax() {
+            return inSingleQuote || inDoubleQuote || depthParen > 0 || depthBracket > 0 || depthBrace > 0;
+        }
+
+        private boolean isBalanced() {
+            return !inSingleQuote && !inDoubleQuote && depthParen == 0 && depthBracket == 0 && depthBrace == 0;
+        }
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
@@ -1,5 +1,6 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.rendering;
 
+import io.github.wamukat.thymeleaflet.domain.service.TopLevelSyntaxScanner;
 import org.thymeleaf.engine.AbstractTemplateHandler;
 import org.thymeleaf.model.IAttribute;
 import org.thymeleaf.model.IOpenElementTag;
@@ -10,6 +11,8 @@ import java.util.Locale;
 import java.util.Optional;
 
 public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHandler {
+
+    private static final TopLevelSyntaxScanner TOP_LEVEL_SYNTAX_SCANNER = new TopLevelSyntaxScanner();
 
     @Override
     public void handleOpenElement(IOpenElementTag tag) {
@@ -83,15 +86,11 @@ public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHa
         }
 
         private Optional<Integer> findTopLevelFragmentSeparator() {
-            ScanState state = new ScanState();
-            for (int index = bodyStart; index < bodyEnd - 1; index++) {
-                char current = value.charAt(index);
-                if (!state.isInsideNestedSyntax() && current == ':' && value.charAt(index + 1) == ':') {
-                    return Optional.of(index);
-                }
-                state.accept(current);
+            var separatorIndex = TOP_LEVEL_SYNTAX_SCANNER.findFirst(value, "::", bodyStart, bodyEnd);
+            if (separatorIndex.isEmpty()) {
+                return Optional.empty();
             }
-            return Optional.empty();
+            return Optional.of(separatorIndex.getAsInt());
         }
 
         private Optional<String> normalizeSelector(int selectorStart) {
@@ -163,15 +162,7 @@ public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHa
         }
 
         private static int findTopLevelOpenParen(String value) {
-            ScanState state = new ScanState();
-            for (int index = 0; index < value.length(); index++) {
-                char current = value.charAt(index);
-                if (!state.isInsideNestedSyntax() && current == '(') {
-                    return index;
-                }
-                state.accept(current);
-            }
-            return -1;
+            return TOP_LEVEL_SYNTAX_SCANNER.findFirst(value, "(").orElse(-1);
         }
 
         private static int lastNonWhitespaceIndex(String value) {
@@ -196,45 +187,4 @@ public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHa
         }
     }
 
-    private static final class ScanState {
-        private int depthParen;
-        private int depthBracket;
-        private int depthBrace;
-        private boolean inSingleQuote;
-        private boolean inDoubleQuote;
-        private char previous;
-
-        private void accept(char current) {
-            if (current == '\'' && !inDoubleQuote && previous != '\\') {
-                inSingleQuote = !inSingleQuote;
-                previous = current;
-                return;
-            }
-            if (current == '"' && !inSingleQuote && previous != '\\') {
-                inDoubleQuote = !inDoubleQuote;
-                previous = current;
-                return;
-            }
-            if (!inSingleQuote && !inDoubleQuote) {
-                if (current == '(') {
-                    depthParen++;
-                } else if (current == ')' && depthParen > 0) {
-                    depthParen--;
-                } else if (current == '[') {
-                    depthBracket++;
-                } else if (current == ']' && depthBracket > 0) {
-                    depthBracket--;
-                } else if (current == '{') {
-                    depthBrace++;
-                } else if (current == '}' && depthBrace > 0) {
-                    depthBrace--;
-                }
-            }
-            previous = current;
-        }
-
-        private boolean isInsideNestedSyntax() {
-            return inSingleQuote || inDoubleQuote || depthParen > 0 || depthBracket > 0 || depthBrace > 0;
-        }
-    }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TopLevelSyntaxScannerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TopLevelSyntaxScannerTest.java
@@ -1,0 +1,49 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TopLevelSyntaxScannerTest {
+
+    private final TopLevelSyntaxScanner scanner = new TopLevelSyntaxScanner();
+
+    @Test
+    void findFirst_shouldFindTokenOnlyAtTopLevel() {
+        String value = "layout :: wrapper(label='a :: b', child=~{child :: body()}) :: target";
+
+        assertThat(scanner.findFirst(value, "::")).hasValue(7);
+    }
+
+    @Test
+    void findFirst_shouldSupportBoundedSearch() {
+        String value = "prefix :: card()";
+        int bodyStart = "prefix :: ".length();
+
+        assertThat(scanner.findFirst(value, "(", bodyStart, value.length()))
+            .hasValue("prefix :: card".length());
+    }
+
+    @Test
+    void split_shouldIgnoreSeparatorsInsideQuotesAndNestedSyntax() {
+        TopLevelSyntaxScanner.SplitResult result = scanner.split(
+            "label='a,b', items=${view.items[0]}, child=~{x :: y(a='b,c')}",
+            ','
+        );
+
+        assertThat(result.isBalanced()).isTrue();
+        assertThat(result.segments()).containsExactly(
+            "label='a,b'",
+            " items=${view.items[0]}",
+            " child=~{x :: y(a='b,c')}"
+        );
+    }
+
+    @Test
+    void split_shouldReportUnbalancedNestedSyntax() {
+        TopLevelSyntaxScanner.SplitResult result = scanner.split("label=${view.title", ',');
+
+        assertThat(result.isBalanced()).isFalse();
+        assertThat(result.segments()).containsExactly("label=${view.title");
+    }
+}


### PR DESCRIPTION
## Summary

- add a reusable TopLevelSyntaxScanner for quote/nested-syntax aware top-level token scanning
- migrate FragmentExpressionParser separator and argument splitting to the shared scanner
- migrate no-arg fragment reference preprocessing to the shared scanner and remove duplicate ScanState logic

Closes #508

## Verification

- ./mvnw -q -Dtest=TopLevelSyntaxScannerTest,FragmentExpressionParserTest,NoArgFragmentReferencePreProcessorTest test
- npm run test:workflow
- ./mvnw test -q
- npm run test:e2e:local
- git diff --check
