### PR TITLE
Surface parser diagnostics in story diagnostics

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/application/port/outbound/FragmentCatalogPort.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/port/outbound/FragmentCatalogPort.java
@@ -1,6 +1,7 @@
 package io.github.wamukat.thymeleaflet.application.port.outbound;
 
 import io.github.wamukat.thymeleaflet.domain.model.FragmentSummary;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,5 +19,8 @@ public interface FragmentCatalogPort {
             .filter(fragment -> fragment.getFragmentName().equals(fragmentName))
             .findFirst();
     }
-}
 
+    default List<ParserDiagnostic> getTemplateParserDiagnostics(String templatePath) {
+        return List.of();
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
@@ -9,6 +9,7 @@ import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryConfigurat
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryGroup;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryItem;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryPreview;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -119,12 +120,34 @@ public class StoryRetrievalUseCaseImpl implements StoryRetrievalUseCase {
 
     @Override
     public Optional<StoryConfigurationDiagnostic> getStoryConfigurationDiagnostic(String templatePath) {
-        return storyDataPort.getStoryConfigurationDiagnostic(templatePath)
+        Optional<StoryConfigurationDiagnostic> storyDiagnostic = storyDataPort.getStoryConfigurationDiagnostic(templatePath)
             .map(diagnostic -> new StoryConfigurationDiagnostic(
                 diagnostic.code(),
                 diagnostic.userSafeMessage(),
                 diagnostic.developerMessage()
             ));
+        if (storyDiagnostic.isPresent()) {
+            return storyDiagnostic;
+        }
+        return fragmentCatalogPort.getTemplateParserDiagnostics(templatePath).stream()
+            .findFirst()
+            .map(this::toStoryConfigurationDiagnostic);
+    }
+
+    private StoryConfigurationDiagnostic toStoryConfigurationDiagnostic(ParserDiagnostic diagnostic) {
+        return new StoryConfigurationDiagnostic(
+            diagnostic.code(),
+            "Some template syntax was skipped while analyzing this story.",
+            diagnosticDeveloperMessage(diagnostic)
+        );
+    }
+
+    private String diagnosticDeveloperMessage(ParserDiagnostic diagnostic) {
+        String location = "";
+        if (diagnostic.line() > 0 && diagnostic.column() > 0) {
+            location = " at line " + diagnostic.line() + ", column " + diagnostic.column();
+        }
+        return diagnostic.message() + location;
     }
 
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentCatalogAdapter.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentCatalogAdapter.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentCatalogPort;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentSummary;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSummaryMapper;
 import org.springframework.stereotype.Component;
 
@@ -30,5 +31,9 @@ public class FragmentCatalogAdapter implements FragmentCatalogPort {
             .map(fragmentSummaryMapper::toDomain)
             .toList();
     }
-}
 
+    @Override
+    public List<ParserDiagnostic> getTemplateParserDiagnostics(String templatePath) {
+        return fragmentDiscoveryService.findTemplateParserDiagnostics(templatePath);
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -1,6 +1,9 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +13,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Thymeleafフラグメントを自動発見・解析するサービス
@@ -19,11 +24,22 @@ import java.util.Optional;
 public class FragmentDiscoveryService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentDiscoveryService.class);
+
+    private static final Set<String> FRAGMENT_REFERENCE_ATTRIBUTES = Set.of(
+        "th:replace",
+        "th:insert",
+        "th:include",
+        "data-th-replace",
+        "data-th-insert",
+        "data-th-include"
+    );
     
     private final TemplateScanner templateScanner;
     private final FragmentDefinitionParser fragmentDefinitionParser;
     private final FragmentDomainService fragmentDomainService;
     private final FragmentSignatureParser fragmentSignatureParser;
+    private final StructuredTemplateParser structuredTemplateParser = new StructuredTemplateParser();
+    private final FragmentExpressionParser fragmentExpressionParser = new FragmentExpressionParser();
     private final ThymeleafletCacheManager cacheManager;
 
     public FragmentDiscoveryService(
@@ -78,6 +94,36 @@ public class FragmentDiscoveryService {
         List<FragmentInfo> immutableFragments = Collections.unmodifiableList(new ArrayList<>(fragments));
         cacheManager.put("fragment-discovery", "all", immutableFragments);
         return immutableFragments;
+    }
+
+    public List<ParserDiagnostic> findTemplateParserDiagnostics(String templatePath) {
+        try {
+            for (TemplateScanner.TemplateResource template : templateScanner.scanTemplates()) {
+                if (!template.templatePath().equals(templatePath)) {
+                    continue;
+                }
+                return parserDiagnostics(template.content());
+            }
+        } catch (IOException exception) {
+            logger.warn("Failed to scan template diagnostics for {}: {}", templatePath, exception.getMessage());
+        }
+        return List.of();
+    }
+
+    private List<ParserDiagnostic> parserDiagnostics(String templateContent) {
+        StructuredTemplateParser.TemplateParseResult parseResult =
+            structuredTemplateParser.parseWithDiagnostics(templateContent);
+        List<ParserDiagnostic> diagnostics = new ArrayList<>(parseResult.diagnostics());
+        for (StructuredTemplateParser.TemplateElement element : parseResult.parsedTemplate().elements()) {
+            for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                if (!attribute.hasValue()
+                    || !FRAGMENT_REFERENCE_ATTRIBUTES.contains(attribute.name().toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+                diagnostics.addAll(fragmentExpressionParser.parseWithDiagnostics(attribute.value()).diagnostics());
+            }
+        }
+        return List.copyOf(diagnostics);
     }
     
     /**

--- a/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.application.service.story;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.StoryDataPort;
 import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryRetrievalUseCase.StoryConfigurationDiagnostic;
+import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentCatalogPort;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentSummary;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryConfiguration;
@@ -10,6 +11,7 @@ import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryItem;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryMeta;
 import io.github.wamukat.thymeleaflet.domain.model.configuration.StoryPreview;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery.FragmentDiscoveryService;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.mapper.FragmentSummaryMapper;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,9 @@ class StoryRetrievalUseCaseImplTest {
 
     @Mock
     private StoryDataPort storyDataPort;
+
+    @Mock
+    private FragmentCatalogPort fragmentCatalogPort;
 
     @Mock
     private FragmentSummaryMapper fragmentSummaryMapper;
@@ -117,7 +122,7 @@ class StoryRetrievalUseCaseImplTest {
                 "STORY_YAML_LOAD_FAILED",
                 "Story configuration could not be loaded or parsed.",
                 "Failed to parse classpath:META-INF/thymeleaflet/stories/components/profile.stories.yml"
-            );
+        );
         when(storyDataPort.getStoryConfigurationDiagnostic("components/profile"))
             .thenReturn(Optional.of(outboundDiagnostic));
 
@@ -135,9 +140,34 @@ class StoryRetrievalUseCaseImplTest {
     @Test
     void shouldReturnEmptyStoryConfigurationDiagnosticWhenStoryDataPortHasNoDiagnostic() {
         when(storyDataPort.getStoryConfigurationDiagnostic("components/profile")).thenReturn(Optional.empty());
+        when(fragmentCatalogPort.getTemplateParserDiagnostics("components/profile")).thenReturn(List.of());
 
         Optional<StoryConfigurationDiagnostic> diagnostic = useCase.getStoryConfigurationDiagnostic("components/profile");
 
         assertThat(diagnostic).isEmpty();
+    }
+
+    @Test
+    void shouldMapParserDiagnosticWhenStoryConfigurationHasNoDiagnostic() {
+        when(storyDataPort.getStoryConfigurationDiagnostic("components/profile")).thenReturn(Optional.empty());
+        when(fragmentCatalogPort.getTemplateParserDiagnostics("components/profile"))
+            .thenReturn(List.of(new ParserDiagnostic(
+                "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED",
+                "Dynamic fragment reference was skipped in `th:replace`",
+                3,
+                12
+            )));
+
+        Optional<StoryConfigurationDiagnostic> diagnostic = useCase.getStoryConfigurationDiagnostic("components/profile");
+
+        assertThat(diagnostic).hasValueSatisfying(mappedDiagnostic -> {
+            assertThat(mappedDiagnostic.code()).isEqualTo("TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED");
+            assertThat(mappedDiagnostic.userSafeMessage())
+                .isEqualTo("Some template syntax was skipped while analyzing this story.");
+            assertThat(mappedDiagnostic.developerMessage())
+                .contains("Dynamic fragment reference was skipped in `th:replace`")
+                .contains("line 3")
+                .contains("column 12");
+        });
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
@@ -1,0 +1,54 @@
+package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
+import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FragmentDiscoveryServiceTemplateDiagnosticsTest {
+
+    private final TemplateScanner templateScanner = mock(TemplateScanner.class);
+    private final FragmentDiscoveryService discoveryService = new FragmentDiscoveryService(
+        templateScanner,
+        mock(FragmentDefinitionParser.class),
+        mock(FragmentDomainService.class),
+        mock(FragmentSignatureParser.class),
+        mock(ThymeleafletCacheManager.class)
+    );
+
+    @Test
+    void findTemplateParserDiagnostics_shouldReturnDynamicFragmentReferenceWarnings() throws IOException {
+        when(templateScanner.scanTemplates()).thenReturn(List.of(
+            new TemplateScanner.TemplateResource(
+                "components/profile",
+                """
+                    <section>
+                      <div th:replace="${dynamicReference}"></div>
+                      <div th:insert="~{components/card}"></div>
+                    </section>
+                    """,
+                "classpath:/templates/components/profile.html"
+            )
+        ));
+
+        List<ParserDiagnostic> diagnostics = discoveryService.findTemplateParserDiagnostics("components/profile");
+
+        assertThat(diagnostics)
+            .anySatisfy(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED");
+                assertThat(diagnostic.message()).contains("th:replace");
+                assertThat(diagnostic.line()).isGreaterThan(0);
+                assertThat(diagnostic.column()).isGreaterThan(0);
+            })
+            .anySatisfy(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_EXPRESSION_MALFORMED");
+                assertThat(diagnostic.message()).contains("components/card");
+            });
+    }
+}


### PR DESCRIPTION
## Summary

- Surface parser diagnostics through the existing story diagnostic path.
- Add template-level parser diagnostics discovery for fragment reference attributes.
- Keep unsupported or malformed syntax non-fatal while exposing a user-safe diagnostic.

Closes #509

## Verification

- `./mvnw -q -Dtest=StoryRetrievalUseCaseImplTest,FragmentDiscoveryServiceTemplateDiagnosticsTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

## Review

- Sub-agent review: No findings.
