### PR TITLE
Extract parser comparison test contract

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -133,7 +133,7 @@ list 内の値を記述する場合は `@model` path に `[]` を使います。
 
 ## 外部パーサ評価
 
-`HtmlParserAdapterComparisonTest` は、外部 HTML パーサを Thymeleaflet の parser corpus に対して評価するための比較 spike です。現在の候補は jsoup で、依存は test scope のみに限定しています。このテストハーネスは regression corpus を `StructuredTemplateParser` と候補アダプタの両方で解析し、次の契約を比較します。
+`HtmlParserAdapterComparisonTest` は、外部 HTML パーサを Thymeleaflet の parser corpus に対して評価するための比較 spike です。現在の候補は jsoup で、依存は test scope のみに限定しています。`io.github.wamukat.thymeleaflet.testsupport.parser` の reusable test-support contract は regression corpus を `StructuredTemplateParser` と候補アダプタの両方で解析し、次の契約を比較します。
 
 - `th:*`、`data-th-*`、quote 付き fragment selector、複数行値、literal `>`、boolean 属性に隣接する属性を含め、Thymeleaf 属性名と値を保持できること。
 - fragment 宣言を source order で発見できること。

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -133,7 +133,7 @@ When adding syntax support, prefer parser-owned tests over broad end-to-end asse
 
 ## External Parser Evaluation
 
-`HtmlParserAdapterComparisonTest` is the comparison spike for evaluating external HTML parsers against the Thymeleaflet parser corpus. The current candidate is jsoup, added only as a test-scoped dependency. The test harness runs the regression corpus through both `StructuredTemplateParser` and the candidate adapter, then compares these contract points:
+`HtmlParserAdapterComparisonTest` is the comparison spike for evaluating external HTML parsers against the Thymeleaflet parser corpus. The current candidate is jsoup, added only as a test-scoped dependency. The reusable test-support contract in `io.github.wamukat.thymeleaflet.testsupport.parser` runs the regression corpus through both `StructuredTemplateParser` and a candidate adapter, then compares these contract points:
 
 - Thymeleaf attribute names and values are preserved, including `th:*`, `data-th-*`, quoted fragment selectors, multiline values, literal `>` characters, and boolean-adjacent attributes.
 - Fragment declarations remain discoverable in source order.

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/HtmlParserAdapterComparisonTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/HtmlParserAdapterComparisonTest.java
@@ -3,6 +3,10 @@ package io.github.wamukat.thymeleaflet.domain.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.wamukat.thymeleaflet.testsupport.FixtureResources;
+import io.github.wamukat.thymeleaflet.testsupport.parser.CandidateElement;
+import io.github.wamukat.thymeleaflet.testsupport.parser.CandidateHtmlParserAdapter;
+import io.github.wamukat.thymeleaflet.testsupport.parser.CandidateTemplate;
+import io.github.wamukat.thymeleaflet.testsupport.parser.ParserComparisonContract;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Element;
@@ -11,11 +15,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 class HtmlParserAdapterComparisonTest {
@@ -25,14 +26,11 @@ class HtmlParserAdapterComparisonTest {
 
     @Test
     void jsoupAdapter_shouldPreserveThymeleafAttributesAcrossRegressionCorpus() {
-        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+        ParserComparisonContract.Comparison comparison = comparison();
 
-        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
-        CandidateTemplate candidate = jsoupAdapter.parse(html);
-
-        assertThat(candidate.thymeleafAttributes())
-            .containsAll(currentThymeleafAttributes(current));
-        assertThat(candidate.thymeleafAttributes())
+        assertThat(comparison.candidate().thymeleafAttributes())
+            .containsAll(comparison.currentThymeleafAttributes());
+        assertThat(comparison.candidate().thymeleafAttributes())
             .contains(
                 "data-th-each=item : ${view.items}",
                 "th:replace=~{'regression/parser-corpus' :: quotedTarget(label=${view.label})}",
@@ -45,32 +43,26 @@ class HtmlParserAdapterComparisonTest {
 
     @Test
     void jsoupAdapter_shouldKeepFragmentDeclarationOrderStableForCorpus() {
-        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+        ParserComparisonContract.Comparison comparison = comparison();
 
-        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
-        CandidateTemplate candidate = jsoupAdapter.parse(html);
-
-        assertThat(candidate.fragmentDefinitions())
-            .containsSequence(currentFragmentDefinitions(current));
+        assertThat(comparison.candidate().fragmentDefinitions())
+            .containsSequence(comparison.currentFragmentDefinitions());
     }
 
     @Test
     void jsoupAdapter_shouldTolerateMalformedHtmlButNotReplaceCurrentParserCapabilities() {
-        String html = FixtureResources.text("templates/regression/parser-corpus.html");
+        ParserComparisonContract.Comparison comparison = comparison();
 
-        StructuredTemplateParser.ParsedTemplate current = structuredParser.parse(html);
-        CandidateTemplate candidate = jsoupAdapter.parse(html);
-
-        assertThat(currentElement(current, "malformedHtmlShell").attributeValue("th:fragment"))
+        assertThat(comparison.currentElement("malformedHtmlShell").attributeValue("th:fragment"))
             .hasValue("malformedHtmlShell");
-        assertThat(candidate.element("malformedHtmlShell").flatMap(element -> element.attributeValue("th:fragment")))
+        assertThat(comparison.candidate().element("malformedHtmlShell").flatMap(element -> element.attributeValue("th:fragment")))
             .hasValue("malformedHtmlShell");
-        assertThat(candidate.thymeleafAttributes())
+        assertThat(comparison.candidate().thymeleafAttributes())
             .contains("data-th-text=${view.malformed.label}");
 
-        assertThat(current.elements())
+        assertThat(comparison.current().elements())
             .allSatisfy(element -> assertThat(element.line()).isPositive());
-        assertThat(candidate.hasSourcePositions()).isFalse();
+        assertThat(comparison.candidate().hasSourcePositions()).isFalse();
     }
 
     @Test
@@ -87,27 +79,11 @@ class HtmlParserAdapterComparisonTest {
             .doesNotContain("${view.boundary.a}");
     }
 
-    private static List<String> currentThymeleafAttributes(StructuredTemplateParser.ParsedTemplate parsed) {
-        return parsed.elements().stream()
-            .flatMap(element -> element.thymeleafAttributes().stream())
-            .map(attribute -> attribute.name() + "=" + attribute.value())
-            .toList();
-    }
-
-    private static List<String> currentFragmentDefinitions(StructuredTemplateParser.ParsedTemplate parsed) {
-        return parsed.elements().stream()
-            .flatMap(element -> element.attributeValue("th:fragment").stream())
-            .toList();
-    }
-
-    private static StructuredTemplateParser.TemplateElement currentElement(
-        StructuredTemplateParser.ParsedTemplate parsed,
-        String fragmentName
-    ) {
-        return parsed.elements().stream()
-            .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
-            .findFirst()
-            .orElseThrow();
+    private ParserComparisonContract.Comparison comparison() {
+        return new ParserComparisonContract(structuredParser).compare(
+            FixtureResources.text("templates/regression/parser-corpus.html"),
+            jsoupAdapter
+        );
     }
 
     private static List<String> attributeValues(List<CandidateElement> elements, String attributeName) {
@@ -116,9 +92,10 @@ class HtmlParserAdapterComparisonTest {
             .toList();
     }
 
-    private static final class JsoupTemplateParserAdapter {
+    private static final class JsoupTemplateParserAdapter implements CandidateHtmlParserAdapter {
 
-        CandidateTemplate parse(String html) {
+        @Override
+        public CandidateTemplate parse(String html) {
             Objects.requireNonNull(html, "html cannot be null");
             Element root = Jsoup.parse(html, "", Parser.htmlParser());
             List<CandidateElement> elements = new ArrayList<>();
@@ -138,93 +115,6 @@ class HtmlParserAdapterComparisonTest {
             for (Element child : element.children()) {
                 collect(child, index, depth + 1, elements);
             }
-        }
-    }
-
-    private record CandidateTemplate(List<CandidateElement> elements) {
-        CandidateTemplate {
-            elements = List.copyOf(elements);
-        }
-
-        List<String> thymeleafAttributes() {
-            return elements.stream()
-                .flatMap(element -> element.thymeleafAttributes().stream())
-                .toList();
-        }
-
-        List<String> fragmentDefinitions() {
-            return elements.stream()
-                .flatMap(element -> element.attributeValue("th:fragment").stream())
-                .toList();
-        }
-
-        Optional<CandidateElement> element(String fragmentName) {
-            return elements.stream()
-                .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
-                .findFirst();
-        }
-
-        List<CandidateElement> subtree(CandidateElement root) {
-            Map<Integer, CandidateElement> byIndex = elements.stream()
-                .collect(Collectors.toUnmodifiableMap(CandidateElement::index, element -> element));
-            Predicate<CandidateElement> isRootOrDescendant =
-                element -> element.index() == root.index() || isDescendantOf(element, root.index(), byIndex);
-            return elements.stream()
-                .filter(isRootOrDescendant)
-                .toList();
-        }
-
-        boolean hasSourcePositions() {
-            return false;
-        }
-
-        private static boolean isDescendantOf(
-            CandidateElement candidate,
-            int rootIndex,
-            Map<Integer, CandidateElement> byIndex
-        ) {
-            int parentIndex = candidate.parentIndex();
-            while (parentIndex >= 0) {
-                if (parentIndex == rootIndex) {
-                    return true;
-                }
-                CandidateElement parent = byIndex.get(parentIndex);
-                if (parent == null) {
-                    return false;
-                }
-                parentIndex = parent.parentIndex();
-            }
-            return false;
-        }
-    }
-
-    private record CandidateElement(
-        String name,
-        Map<String, String> attributes,
-        int index,
-        int parentIndex,
-        int depth
-    ) {
-        CandidateElement {
-            name = name.trim();
-            attributes = Map.copyOf(attributes);
-        }
-
-        Optional<String> attributeValue(String attributeName) {
-            Objects.requireNonNull(attributeName, "attributeName cannot be null");
-            return Optional.ofNullable(attributes.get(attributeName));
-        }
-
-        List<String> thymeleafAttributes() {
-            return attributes.entrySet().stream()
-                .filter(entry -> isThymeleafAttribute(entry.getKey()))
-                .map(entry -> entry.getKey() + "=" + entry.getValue())
-                .toList();
-        }
-
-        private static boolean isThymeleafAttribute(String name) {
-            String normalized = name.toLowerCase(Locale.ROOT);
-            return normalized.startsWith("th:") || normalized.startsWith("data-th-");
         }
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateElement.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateElement.java
@@ -1,0 +1,37 @@
+package io.github.wamukat.thymeleaflet.testsupport.parser;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public record CandidateElement(
+    String name,
+    Map<String, String> attributes,
+    int index,
+    int parentIndex,
+    int depth
+) {
+    public CandidateElement {
+        name = name.trim();
+        attributes = Map.copyOf(attributes);
+    }
+
+    public Optional<String> attributeValue(String attributeName) {
+        Objects.requireNonNull(attributeName, "attributeName cannot be null");
+        return Optional.ofNullable(attributes.get(attributeName));
+    }
+
+    public List<String> thymeleafAttributes() {
+        return attributes.entrySet().stream()
+            .filter(entry -> isThymeleafAttribute(entry.getKey()))
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .toList();
+    }
+
+    private static boolean isThymeleafAttribute(String name) {
+        String normalized = name.toLowerCase(Locale.ROOT);
+        return normalized.startsWith("th:") || normalized.startsWith("data-th-");
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateHtmlParserAdapter.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateHtmlParserAdapter.java
@@ -1,0 +1,6 @@
+package io.github.wamukat.thymeleaflet.testsupport.parser;
+
+public interface CandidateHtmlParserAdapter {
+
+    CandidateTemplate parse(String html);
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplate.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplate.java
@@ -1,0 +1,64 @@
+package io.github.wamukat.thymeleaflet.testsupport.parser;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public record CandidateTemplate(List<CandidateElement> elements) {
+    public CandidateTemplate {
+        elements = List.copyOf(elements);
+    }
+
+    public List<String> thymeleafAttributes() {
+        return elements.stream()
+            .flatMap(element -> element.thymeleafAttributes().stream())
+            .toList();
+    }
+
+    public List<String> fragmentDefinitions() {
+        return elements.stream()
+            .flatMap(element -> element.attributeValue("th:fragment").stream())
+            .toList();
+    }
+
+    public Optional<CandidateElement> element(String fragmentName) {
+        return elements.stream()
+            .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
+            .findFirst();
+    }
+
+    public List<CandidateElement> subtree(CandidateElement root) {
+        Map<Integer, CandidateElement> byIndex = elements.stream()
+            .collect(Collectors.toUnmodifiableMap(CandidateElement::index, element -> element));
+        Predicate<CandidateElement> isRootOrDescendant =
+            element -> element.index() == root.index() || isDescendantOf(element, root.index(), byIndex);
+        return elements.stream()
+            .filter(isRootOrDescendant)
+            .toList();
+    }
+
+    public boolean hasSourcePositions() {
+        return false;
+    }
+
+    private static boolean isDescendantOf(
+        CandidateElement candidate,
+        int rootIndex,
+        Map<Integer, CandidateElement> byIndex
+    ) {
+        int parentIndex = candidate.parentIndex();
+        while (parentIndex >= 0) {
+            if (parentIndex == rootIndex) {
+                return true;
+            }
+            CandidateElement parent = byIndex.get(parentIndex);
+            if (parent == null) {
+                return false;
+            }
+            parentIndex = parent.parentIndex();
+        }
+        return false;
+    }
+}

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/ParserComparisonContract.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/ParserComparisonContract.java
@@ -1,0 +1,47 @@
+package io.github.wamukat.thymeleaflet.testsupport.parser;
+
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class ParserComparisonContract {
+
+    private final StructuredTemplateParser structuredParser;
+
+    public ParserComparisonContract(StructuredTemplateParser structuredParser) {
+        this.structuredParser = Objects.requireNonNull(structuredParser, "structuredParser cannot be null");
+    }
+
+    public Comparison compare(String html, CandidateHtmlParserAdapter candidateAdapter) {
+        Objects.requireNonNull(html, "html cannot be null");
+        Objects.requireNonNull(candidateAdapter, "candidateAdapter cannot be null");
+        return new Comparison(structuredParser.parse(html), candidateAdapter.parse(html));
+    }
+
+    public record Comparison(
+        StructuredTemplateParser.ParsedTemplate current,
+        CandidateTemplate candidate
+    ) {
+        public List<String> currentThymeleafAttributes() {
+            return current.elements().stream()
+                .flatMap(element -> element.thymeleafAttributes().stream())
+                .map(attribute -> attribute.name() + "=" + attribute.value())
+                .toList();
+        }
+
+        public List<String> currentFragmentDefinitions() {
+            return current.elements().stream()
+                .flatMap(element -> element.attributeValue("th:fragment").stream())
+                .toList();
+        }
+
+        public StructuredTemplateParser.TemplateElement currentElement(String fragmentName) {
+            Objects.requireNonNull(fragmentName, "fragmentName cannot be null");
+            return current.elements().stream()
+                .filter(element -> element.attributeValue("th:fragment").filter(fragmentName::equals).isPresent())
+                .findFirst()
+                .orElseThrow();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract reusable test-support contracts for external parser comparisons.
- Update the jsoup comparison spike to use the shared candidate parser model.
- Document that the comparison harness is reusable while jsoup remains test-scoped and non-production.

Closes #510

## Verification

- Red first: `./mvnw -q -Dtest=HtmlParserAdapterComparisonTest test` failed before `testsupport.parser` existed
- `./mvnw -q -Dtest=HtmlParserAdapterComparisonTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- First `npm run test:e2e:local` timed out waiting for sample app startup; no stale port/process found, reran cleanly
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

## Review

- Sub-agent review: No findings.
