### PR TITLE
Document fragment syntax support matrix

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -27,6 +27,49 @@
 
 モデル推論レイヤは、以下の属性で `th:*` と `data-th-*` の両方をサポートします。
 
+## Fragment Syntax Support Matrix
+
+状態の意味:
+
+- Supported: runtime または static analysis で解析・利用できる。
+- Diagnostic-only: unsupported / dynamic として認識し、rendering は失敗させない。
+- Unsupported: 安定した意味でまだ解析していない。
+- Intentionally unsupported: Thymeleaf rendering には任せる、または static analysis 対象から意図的に外している。
+
+| Syntax | Status | Notes | Follow-up |
+| --- | --- | --- | --- |
+| `th:fragment="profileCard"` | Supported | simple fragment として discovery / 表示できる。 | declaration parser test で維持する。 |
+| `th:fragment="profileCard()"` | Supported | 空の parameter list を no-argument fragment として正規化する。 | declaration parser test で維持する。 |
+| `th:fragment="profileCard(name, age)"` | Supported | identifier parameter を宣言順で保持する。 | declaration parser test で維持する。 |
+| `data-th-fragment="profileCard(name)"` | Supported | discovery では `data-th-fragment` を `th:fragment` と同様に扱う。 | discovery test で維持する。 |
+| duplicate declaration parameters | Supported as-is | duplicate name は現在 declaration order のまま保持し、uniqueness diagnostic はまだ出していない。 | UI editing が uniqueness に依存する前に直接 diagnostic を追加する。 |
+| declaration parameter defaults / assignment syntax | Unsupported | `profileCard(name='x')` のような declaration 側 syntax は v1 UI support set の外。 | 実テンプレートで必要になった場合のみ再検討する。 |
+| non-identifier declaration names / parameters | Unsupported | Thymeleaf が受け付ける範囲より、Thymeleaflet の正規化出力は狭く保つ。 | 推測で正規化せず diagnostic として扱う。 |
+| `~{components/card :: card(title=${view.title})}` | Supported | static template path、selector、argument list を dependency / model inference に利用する。 | `FragmentExpressionParserTest` で維持する。 |
+| `~{'components/card' :: card(title='Ready')}` | Supported | quote 付き template path と literal argument をサポートする。literal-only call は child model recursion を skip する。 | parser corpus で維持する。 |
+| `~{"components/card" :: content}` | Supported | double quote 付き template path をサポートする。 | parser test で維持する。 |
+| `~{components/topbar :: topbar()}` | Supported | no-argument call を正規化し、child model requirements へ再帰しない。 | no-arg preprocessing test で維持する。 |
+| named call arguments, e.g. `card(title=${view.title})` | Supported as raw arguments | argument name/value は raw segment として保持する。declaration parameter への意味的 mapping は未実施。 | story value ordering が必要とする場合のみ semantic mapping を検討する。 |
+| `th:replace`, `th:insert`, `th:include` | Supported | static fragment expression を解析する。unsupported / dynamic reference は non-fatal に skip する。 | analyzer 間で shared attribute policy を集約する。 |
+| `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | 関連箇所では `data-th-*` variant も parsing / diagnostics 対象に含める。 | analyzer 間で shared attribute policy を集約する。 |
+| fragment reference としての `${dynamicRef}` | Diagnostic-only | dynamic reference は static に解決できないため non-fatal diagnostic を出す。 | story diagnostics への surfaced 状態を維持する。 |
+| malformed fragment expressions | Diagnostic-only | malformed static reference は non-fatal diagnostic を出す。 | 可能なら expression diagnostic の source location を改善する。 |
+| `~{:: header}` のような same-template reference | Unsupported | `FragmentExpressionParser` は現在 non-empty static template path を要求する。 | 優先度の高い feature candidate。 |
+| `~{this :: header}` のような same-template reference | Unsupported | `this` は static path normalization で現在除外している。 | 優先度の高い feature candidate。 |
+| `~{template :: #header}` のような selector-style reference | Unsupported | CSS selector semantics は fragment name として正規化していない。 | matching / UI 表示ルールを定義してから検討する。 |
+| `~{template}` のような whole-template reference | Intentionally unsupported for fragment inference | Thymeleaf は template-level reference を rendering できるが、Thymeleaflet の fragment dependency inference には selector が必要。 | 具体的な preview workflow が出るまでは skip する。 |
+| `~{${view.template} :: card}` のような template path expression | Diagnostic-only | dynamic template path は dependency target が static に分からないため skip する。 | non-fatal のまま維持し、推測 path は作らない。 |
+| nested parentheses / quoted commas を含む fragment expression parameter | Supported | top-level split により nested expression と quote 内 separator を保持する。 | parser test で維持する。 |
+| unbalanced parentheses / quotes を含む fragment expression parameter | Diagnostic-only | fail closed し diagnostic を出す。 | parser test で維持する。 |
+
+推奨サポート順:
+
+1. Same-template static references: `~{:: fragment(...)}` と `~{this :: fragment(...)}`。
+2. `replace` / `insert` / `include` と `data-th-*` の shared fragment reference attribute policy。
+3. story diagnostic surface での複数 parser diagnostics 表示。
+4. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
+5. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+
 ### `th:each`
 
 `th:each` は loop alias を iterable のモデルパスへ紐づけます。iterable 式の最初の推論パスが各 alias の source path になります。

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -27,6 +27,49 @@ Template parsing is intentionally split into small layers:
 
 The model inference layer supports both `th:*` and `data-th-*` forms for the attributes below.
 
+## Fragment Syntax Support Matrix
+
+Status meanings:
+
+- Supported: parsed and used by runtime or static analysis.
+- Diagnostic-only: recognized as unsupported or dynamic without failing rendering.
+- Unsupported: not currently parsed with stable semantics.
+- Intentionally unsupported: accepted only by Thymeleaf rendering or deliberately left out of static analysis.
+
+| Syntax | Status | Notes | Follow-up |
+| --- | --- | --- | --- |
+| `th:fragment="profileCard"` | Supported | Fragment declaration is discovered and displayed as a simple fragment. | Keep covered by declaration parser tests. |
+| `th:fragment="profileCard()"` | Supported | Empty parameter list is normalized as a no-argument fragment. | Keep covered by declaration parser tests. |
+| `th:fragment="profileCard(name, age)"` | Supported | Identifier parameters are preserved in declaration order. | Keep covered by declaration parser tests. |
+| `data-th-fragment="profileCard(name)"` | Supported | Discovery treats `data-th-fragment` like `th:fragment`. | Keep covered by discovery tests. |
+| Duplicate declaration parameters | Supported as-is | Duplicate names are currently preserved in declaration order; no uniqueness diagnostic is emitted yet. | Add a direct diagnostic if UI editing starts relying on uniqueness. |
+| Declaration parameter defaults or assignment syntax | Unsupported | Declaration-side syntax such as `profileCard(name='x')` is outside the v1 UI support set. | Revisit only if real templates need it. |
+| Non-identifier declaration names or parameters | Unsupported | Thymeleaf-compatible parsing may accept more than the UI support set; Thymeleaflet keeps normalized output narrow. | Keep as diagnostic rather than normalizing speculatively. |
+| `~{components/card :: card(title=${view.title})}` | Supported | Static template path, selector, and argument list are parsed for dependency and model inference. | Keep covered by `FragmentExpressionParserTest`. |
+| `~{'components/card' :: card(title='Ready')}` | Supported | Quoted template paths and literal arguments are supported. Literal-only calls skip child model recursion. | Keep covered by parser corpus. |
+| `~{"components/card" :: content}` | Supported | Double-quoted template paths are supported. | Keep covered by parser tests. |
+| `~{components/topbar :: topbar()}` | Supported | No-argument calls are normalized and do not recurse into child model requirements. | Keep covered by no-arg preprocessing tests. |
+| Named call arguments, for example `card(title=${view.title})` | Supported as raw arguments | Argument names and values are preserved as raw segments; they are not mapped to declaration parameters semantically. | Consider semantic named-argument mapping only if preview value ordering needs it. |
+| `th:replace`, `th:insert`, `th:include` | Supported | Static fragment expressions are analyzed. Unsupported or dynamic references are skipped non-fatally. | Centralize the shared attribute policy across analyzers. |
+| `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | `data-th-*` variants are included in parsing and diagnostics where relevant. | Centralize the shared attribute policy across analyzers. |
+| `${dynamicRef}` as a fragment reference | Diagnostic-only | Dynamic references cannot be resolved statically and produce non-fatal diagnostics. | Keep diagnostic surfaced in story diagnostics. |
+| Malformed fragment expressions | Diagnostic-only | Malformed static references produce non-fatal diagnostics. | Improve source location for expression diagnostics when possible. |
+| Same-template references such as `~{:: header}` | Unsupported | `FragmentExpressionParser` currently requires a non-empty static template path. | High-value feature candidate. |
+| Same-template references such as `~{this :: header}` | Unsupported | `this` is currently rejected during static path normalization. | High-value feature candidate. |
+| Selector-style references such as `~{template :: #header}` | Unsupported | CSS selector semantics are not normalized into a fragment name today. | Medium-value candidate; requires UI naming and matching rules. |
+| Whole-template references such as `~{template}` | Intentionally unsupported for fragment inference | Thymeleaf can render template-level references, but Thymeleaflet fragment dependency inference needs a selector. | Keep skipped unless a concrete preview workflow needs it. |
+| Template path expressions such as `~{${view.template} :: card}` | Diagnostic-only | Dynamic template paths are skipped because dependency targets are unknowable statically. | Keep non-fatal; do not infer speculative paths. |
+| Fragment expression parameters with nested parentheses or quoted commas | Supported | Top-level splitting preserves nested expressions and quoted separators. | Keep covered by parser tests. |
+| Fragment expression parameters with unbalanced parentheses or quotes | Diagnostic-only | Parse fails closed and emits diagnostics. | Keep covered by parser tests. |
+
+Recommended support order:
+
+1. Same-template static references: `~{:: fragment(...)}` and `~{this :: fragment(...)}`.
+2. Shared fragment reference attribute policy for `replace` / `insert` / `include` and `data-th-*`.
+3. Multiple parser diagnostics on the story diagnostic surface.
+4. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
+5. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+
 ### `th:each`
 
 `th:each` binds loop aliases to the iterable model path. The first inferred path in the iterable expression becomes the source path for each alias.


### PR DESCRIPTION
## Summary

- Add English/Japanese Thymeleaf fragment syntax support matrices.
- Classify declaration syntax, call-site expressions, dynamic references, same-template references, selector references, named arguments, and `th:*` / `data-th-*` forms.
- Document recommended follow-up support order for parser improvements.

Closes #523

## Verification

- `git diff --check`
- `./mvnw -q -Dtest=ReadmeVersionConsistencyTest test`
- `npm run test:workflow`
- First `npm run test:e2e:local` timed out waiting for sample app startup; no stale port/process found, reran cleanly
- `npm run test:e2e:local` (10 passed)

## Review

- Sub-agent review: No findings after doc classification fix and generated CSS restore.
