### PR TITLE
Inject parsers into fragment discovery service

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,8 +39,8 @@ public class FragmentDiscoveryService {
     private final FragmentDefinitionParser fragmentDefinitionParser;
     private final FragmentDomainService fragmentDomainService;
     private final FragmentSignatureParser fragmentSignatureParser;
-    private final StructuredTemplateParser structuredTemplateParser = new StructuredTemplateParser();
-    private final FragmentExpressionParser fragmentExpressionParser = new FragmentExpressionParser();
+    private final StructuredTemplateParser structuredTemplateParser;
+    private final FragmentExpressionParser fragmentExpressionParser;
     private final ThymeleafletCacheManager cacheManager;
 
     public FragmentDiscoveryService(
@@ -47,13 +48,21 @@ public class FragmentDiscoveryService {
         FragmentDefinitionParser fragmentDefinitionParser,
         FragmentDomainService fragmentDomainService,
         FragmentSignatureParser fragmentSignatureParser,
+        StructuredTemplateParser structuredTemplateParser,
+        FragmentExpressionParser fragmentExpressionParser,
         ThymeleafletCacheManager cacheManager
     ) {
-        this.templateScanner = templateScanner;
-        this.fragmentDefinitionParser = fragmentDefinitionParser;
-        this.fragmentDomainService = fragmentDomainService;
-        this.fragmentSignatureParser = fragmentSignatureParser;
-        this.cacheManager = cacheManager;
+        this.templateScanner = Objects.requireNonNull(templateScanner, "templateScanner cannot be null");
+        this.fragmentDefinitionParser =
+            Objects.requireNonNull(fragmentDefinitionParser, "fragmentDefinitionParser cannot be null");
+        this.fragmentDomainService = Objects.requireNonNull(fragmentDomainService, "fragmentDomainService cannot be null");
+        this.fragmentSignatureParser =
+            Objects.requireNonNull(fragmentSignatureParser, "fragmentSignatureParser cannot be null");
+        this.structuredTemplateParser =
+            Objects.requireNonNull(structuredTemplateParser, "structuredTemplateParser cannot be null");
+        this.fragmentExpressionParser =
+            Objects.requireNonNull(fragmentExpressionParser, "fragmentExpressionParser cannot be null");
+        this.cacheManager = Objects.requireNonNull(cacheManager, "cacheManager cannot be null");
     }
     
     /**

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfiguration.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.wamukat.thymeleaflet.domain.service.DocumentationAnalysisService;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
 import io.github.wamukat.thymeleaflet.domain.service.StoryDataRepository;
 import io.github.wamukat.thymeleaflet.domain.service.StoryParameterDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.domain.service.TemplateModelExpressionAnalyzer;
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.NoArgFragmentReferencePreProcessorDialect;
 import io.github.wamukat.thymeleaflet.infrastructure.web.rendering.ThymeleafletAwareThymeleafView;
@@ -114,6 +116,18 @@ public class StorybookAutoConfiguration {
     @ConditionalOnMissingBean
     public TemplateModelExpressionAnalyzer templateModelExpressionAnalyzer() {
         return new TemplateModelExpressionAnalyzer();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public StructuredTemplateParser structuredTemplateParser() {
+        return new StructuredTemplateParser();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public FragmentExpressionParser fragmentExpressionParser() {
+        return new FragmentExpressionParser();
     }
 
     @Bean

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
@@ -5,7 +5,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
 import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import java.io.IOException;
 import java.util.List;
@@ -19,6 +21,8 @@ class FragmentDiscoveryServiceTemplateDiagnosticsTest {
         mock(FragmentDefinitionParser.class),
         mock(FragmentDomainService.class),
         mock(FragmentSignatureParser.class),
+        new StructuredTemplateParser(),
+        new FragmentExpressionParser(),
         mock(ThymeleafletCacheManager.class)
     );
 


### PR DESCRIPTION
## Summary

- Inject `StructuredTemplateParser` and `FragmentExpressionParser` into `FragmentDiscoveryService`.
- Add default parser beans in `StorybookAutoConfiguration`.
- Update diagnostics test to pass explicit parser collaborators.

Closes #524

## Verification

- `./mvnw -q -Dtest=FragmentDiscoveryServiceTemplateDiagnosticsTest,StorybookAutoConfigurationTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- First `npm run test:e2e:local` timed out waiting for sample app startup; no stale port/process found, reran cleanly
- `npm run test:e2e:local` (10 passed)
- `git diff --check`

## Review

- Sub-agent review: No findings.
