### PR TITLE
Centralize fragment reference attribute policy

### DIFF
--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentReferenceAttributes.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentReferenceAttributes.java
@@ -1,0 +1,47 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import java.util.Locale;
+import java.util.Set;
+
+public final class FragmentReferenceAttributes {
+
+    private static final Set<String> REFERENCE_ATTRIBUTES = Set.of(
+        "th:replace",
+        "th:insert",
+        "th:include",
+        "data-th-replace",
+        "data-th-insert",
+        "data-th-include"
+    );
+
+    private static final Set<String> INSERTION_ATTRIBUTES = Set.of(
+        "th:replace",
+        "th:insert",
+        "data-th-replace",
+        "data-th-insert"
+    );
+
+    private static final Set<String> REPLACEMENT_ATTRIBUTES = Set.of(
+        "th:replace",
+        "data-th-replace"
+    );
+
+    private FragmentReferenceAttributes() {
+    }
+
+    public static boolean isReferenceAttribute(String attributeName) {
+        return REFERENCE_ATTRIBUTES.contains(normalize(attributeName));
+    }
+
+    public static boolean isInsertionAttribute(String attributeName) {
+        return INSERTION_ATTRIBUTES.contains(normalize(attributeName));
+    }
+
+    public static boolean isReplacementAttribute(String attributeName) {
+        return REPLACEMENT_ATTRIBUTES.contains(normalize(attributeName));
+    }
+
+    private static String normalize(String attributeName) {
+        return attributeName.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/StructuredTemplateParser.java
@@ -69,14 +69,7 @@ public class StructuredTemplateParser {
     }
 
     private boolean isFragmentReferenceAttribute(TemplateAttribute attribute) {
-        String normalized = attribute.name().toLowerCase(Locale.ROOT);
-        return attribute.hasValue()
-            && (normalized.equals("th:replace")
-            || normalized.equals("th:insert")
-            || normalized.equals("th:include")
-            || normalized.equals("data-th-replace")
-            || normalized.equals("data-th-insert")
-            || normalized.equals("data-th-include"));
+        return attribute.hasValue() && FragmentReferenceAttributes.isReferenceAttribute(attribute.name());
     }
 
     private boolean isDynamicSyntax(String value) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -195,9 +195,7 @@ public class TemplateModelExpressionAnalyzer {
 
     private Map<String, Boolean> extractReferencedTemplatePaths(StructuredTemplateParser.ParsedTemplate template) {
         Map<String, Boolean> referencedTemplatePaths = new LinkedHashMap<>();
-        for (String raw : thymeleafAttributeValues(template, Set.of(
-            "th:replace", "th:insert", "data-th-replace", "data-th-insert"
-        ))) {
+        for (String raw : fragmentInsertionAttributeValues(template)) {
             if (raw == null || raw.isBlank()) {
                 continue;
             }
@@ -209,6 +207,18 @@ public class TemplateModelExpressionAnalyzer {
                 ));
         }
         return referencedTemplatePaths;
+    }
+
+    private List<String> fragmentInsertionAttributeValues(StructuredTemplateParser.ParsedTemplate template) {
+        List<String> values = new ArrayList<>();
+        for (StructuredTemplateParser.TemplateElement element : template.elements()) {
+            for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                if (attribute.hasValue() && FragmentReferenceAttributes.isInsertionAttribute(attribute.name())) {
+                    values.add(attribute.value());
+                }
+            }
+        }
+        return values;
     }
 
     private boolean requiresChildModelRecursion(FragmentExpression expression) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
 import io.github.wamukat.thymeleaflet.domain.service.FragmentDomainService;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentReferenceAttributes;
 import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
@@ -13,10 +14,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Thymeleafフラグメントを自動発見・解析するサービス
@@ -25,15 +24,6 @@ import java.util.Set;
 public class FragmentDiscoveryService {
     
     private static final Logger logger = LoggerFactory.getLogger(FragmentDiscoveryService.class);
-
-    private static final Set<String> FRAGMENT_REFERENCE_ATTRIBUTES = Set.of(
-        "th:replace",
-        "th:insert",
-        "th:include",
-        "data-th-replace",
-        "data-th-insert",
-        "data-th-include"
-    );
     
     private final TemplateScanner templateScanner;
     private final FragmentDefinitionParser fragmentDefinitionParser;
@@ -126,7 +116,7 @@ public class FragmentDiscoveryService {
         for (StructuredTemplateParser.TemplateElement element : parseResult.parsedTemplate().elements()) {
             for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
                 if (!attribute.hasValue()
-                    || !FRAGMENT_REFERENCE_ATTRIBUTES.contains(attribute.name().toLowerCase(Locale.ROOT))) {
+                    || !FragmentReferenceAttributes.isReferenceAttribute(attribute.name())) {
                     continue;
                 }
                 diagnostics.addAll(fragmentExpressionParser.parseWithDiagnostics(attribute.value()).diagnostics());

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/documentation/JavaDocExampleParser.java
@@ -2,6 +2,7 @@ package io.github.wamukat.thymeleaflet.infrastructure.adapter.documentation;
 
 import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentReferenceAttributes;
 import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import org.slf4j.Logger;
@@ -10,12 +11,10 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 final class JavaDocExampleParser {
 
     private static final Logger logger = LoggerFactory.getLogger(JavaDocExampleParser.class);
-    private static final Set<String> EXAMPLE_REPLACE_ATTRIBUTES = Set.of("th:replace", "data-th-replace");
 
     private final StructuredTemplateParser templateParser;
     private final FragmentExpressionParser fragmentExpressionParser;
@@ -39,8 +38,7 @@ final class JavaDocExampleParser {
             StructuredTemplateParser.ParsedTemplate parsedTemplate = parseResult.parsedTemplate();
             for (StructuredTemplateParser.TemplateElement element : parsedTemplate.elements()) {
                 for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
-                    String normalizedName = attribute.name().toLowerCase(java.util.Locale.ROOT);
-                    if (!attribute.hasValue() || !EXAMPLE_REPLACE_ATTRIBUTES.contains(normalizedName)) {
+                    if (!attribute.hasValue() || !FragmentReferenceAttributes.isReplacementAttribute(attribute.name())) {
                         continue;
                     }
                     FragmentExpressionParser.FragmentExpressionParseResult referenceResult =

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/NoArgFragmentReferencePreProcessor.java
@@ -1,5 +1,6 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.rendering;
 
+import io.github.wamukat.thymeleaflet.domain.service.FragmentReferenceAttributes;
 import io.github.wamukat.thymeleaflet.domain.service.TopLevelSyntaxScanner;
 import org.thymeleaf.engine.AbstractTemplateHandler;
 import org.thymeleaf.model.IAttribute;
@@ -7,7 +8,6 @@ import org.thymeleaf.model.IOpenElementTag;
 import org.thymeleaf.model.IProcessableElementTag;
 import org.thymeleaf.model.IStandaloneElementTag;
 
-import java.util.Locale;
 import java.util.Optional;
 
 public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHandler {
@@ -55,11 +55,7 @@ public final class NoArgFragmentReferencePreProcessor extends AbstractTemplateHa
     }
 
     private static boolean isFragmentInsertionAttribute(IAttribute attribute) {
-        String attributeName = attribute.getAttributeCompleteName().toLowerCase(Locale.ROOT);
-        return attributeName.equals("th:replace")
-            || attributeName.equals("th:insert")
-            || attributeName.equals("data-th-replace")
-            || attributeName.equals("data-th-insert");
+        return FragmentReferenceAttributes.isInsertionAttribute(attribute.getAttributeCompleteName());
     }
 
     private record FragmentExpressionValue(String value, int bodyStart, int bodyEnd) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -4,6 +4,7 @@ import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentDependen
 import io.github.wamukat.thymeleaflet.domain.model.FragmentExpression;
 import io.github.wamukat.thymeleaflet.domain.model.SecureTemplatePath;
 import io.github.wamukat.thymeleaflet.domain.service.FragmentExpressionParser;
+import io.github.wamukat.thymeleaflet.domain.service.FragmentReferenceAttributes;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.infrastructure.cache.ThymeleafletCacheManager;
 import io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery.FragmentSignatureParser;
@@ -33,10 +34,6 @@ public class FragmentDependencyService implements FragmentDependencyPort {
     private static final Logger logger = LoggerFactory.getLogger(FragmentDependencyService.class);
 
     private static final Set<String> FRAGMENT_ATTRIBUTES = Set.of("th:fragment", "data-th-fragment");
-    private static final Set<String> DEPENDENCY_ATTRIBUTES = Set.of(
-        "th:replace", "th:include", "th:insert",
-        "data-th-replace", "data-th-include", "data-th-insert"
-    );
 
     private final ResolvedStorybookConfig storybookConfig;
 
@@ -164,8 +161,7 @@ public class FragmentDependencyService implements FragmentDependencyPort {
         List<String> expressions = new ArrayList<>();
         for (StructuredTemplateParser.TemplateElement element : elements) {
             for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
-                String name = attribute.name().toLowerCase(Locale.ROOT);
-                if (!attribute.hasValue() || !DEPENDENCY_ATTRIBUTES.contains(name)) {
+                if (!attribute.hasValue() || !FragmentReferenceAttributes.isReferenceAttribute(attribute.name())) {
                     continue;
                 }
                 expressions.add(attribute.value().trim());

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetector.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/UnsafeFragmentInsertionDetector.java
@@ -1,20 +1,12 @@
 package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 
+import io.github.wamukat.thymeleaflet.domain.service.FragmentReferenceAttributes;
 import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 final class UnsafeFragmentInsertionDetector {
-
-    private static final Set<String> INSERTION_ATTRIBUTES = Set.of(
-        "th:replace",
-        "th:insert",
-        "data-th-replace",
-        "data-th-insert"
-    );
 
     private final StructuredTemplateParser templateParser;
 
@@ -56,7 +48,7 @@ final class UnsafeFragmentInsertionDetector {
         return parsedTemplate.elements().stream()
             .flatMap(element -> element.attributes().stream())
             .filter(attribute -> attribute.hasValue())
-            .filter(attribute -> INSERTION_ATTRIBUTES.contains(attribute.name().toLowerCase(Locale.ROOT)))
+            .filter(attribute -> FragmentReferenceAttributes.isInsertionAttribute(attribute.name()))
             .anyMatch(attribute -> isParameterExpression(attribute.value(), parameterName));
     }
 

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentReferenceAttributesTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentReferenceAttributesTest.java
@@ -1,0 +1,46 @@
+package io.github.wamukat.thymeleaflet.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FragmentReferenceAttributesTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "th:replace",
+        "th:insert",
+        "th:include",
+        "data-th-replace",
+        "data-th-insert",
+        "data-th-include"
+    })
+    void isReferenceAttribute_shouldCoverStaticFragmentReferenceAttributes(String attributeName) {
+        assertThat(FragmentReferenceAttributes.isReferenceAttribute(attributeName)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"th:replace", "th:insert", "data-th-replace", "data-th-insert"})
+    void isInsertionAttribute_shouldCoverReplaceAndInsertOnly(String attributeName) {
+        assertThat(FragmentReferenceAttributes.isInsertionAttribute(attributeName)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"th:include", "data-th-include", "th:text"})
+    void isInsertionAttribute_shouldExcludeIncludeAndNonReferenceAttributes(String attributeName) {
+        assertThat(FragmentReferenceAttributes.isInsertionAttribute(attributeName)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"th:replace", "data-th-replace"})
+    void isReplacementAttribute_shouldCoverJavaDocExampleReplacementAttributes(String attributeName) {
+        assertThat(FragmentReferenceAttributes.isReplacementAttribute(attributeName)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"th:insert", "data-th-insert", "th:include", "data-th-include", "th:text"})
+    void isReplacementAttribute_shouldExcludeNonReplacementAttributes(String attributeName) {
+        assertThat(FragmentReferenceAttributes.isReplacementAttribute(attributeName)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Centralize fragment reference attribute policy in `FragmentReferenceAttributes`
- Reuse the shared policy from diagnostics, dependency extraction, model recursion, unsafe insertion detection, no-arg preprocessing, and JavaDoc example parsing
- Add focused tests for reference, insertion, replacement, and negative replacement attribute classification

## Verification

- `./mvnw -q -Dtest=FragmentReferenceAttributesTest,TemplateModelExpressionAnalyzerTest,FragmentDependencyServiceTest,UnsafeFragmentInsertionDetectorTest,FragmentDiscoveryServiceTemplateDiagnosticsTest,JavaDocExampleParserTest,NoArgFragmentReferencePreProcessorTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes #525
