### PR TITLE
Support same-template fragment references

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -54,8 +54,8 @@
 | `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | 関連箇所では `data-th-*` variant も parsing / diagnostics 対象に含める。 | analyzer 間で shared attribute policy を集約する。 |
 | fragment reference としての `${dynamicRef}` | Diagnostic-only | dynamic reference は static に解決できないため non-fatal diagnostic を出す。 | story diagnostics への surfaced 状態を維持する。 |
 | malformed fragment expressions | Diagnostic-only | malformed static reference は non-fatal diagnostic を出す。 | 可能なら expression diagnostic の source location を改善する。 |
-| `~{:: header}` のような same-template reference | Unsupported | `FragmentExpressionParser` は現在 non-empty static template path を要求する。 | 優先度の高い feature candidate。 |
-| `~{this :: header}` のような same-template reference | Unsupported | `this` は static path normalization で現在除外している。 | 優先度の高い feature candidate。 |
+| `~{:: header}` のような same-template reference | Supported with current-template context | static analyzer は空の template path を現在の template path として解決する。current-template context なしの parser call は fail closed のまま。 | parser / dependency / model inference test で維持する。 |
+| `~{this :: header}` のような same-template reference | Supported with current-template context | static analyzer は `this` を現在の template path として解決する。current-template context なしの parser call は fail closed のまま。 | parser / dependency / model inference test で維持する。 |
 | `~{template :: #header}` のような selector-style reference | Unsupported | CSS selector semantics は fragment name として正規化していない。 | matching / UI 表示ルールを定義してから検討する。 |
 | `~{template}` のような whole-template reference | Intentionally unsupported for fragment inference | Thymeleaf は template-level reference を rendering できるが、Thymeleaflet の fragment dependency inference には selector が必要。 | 具体的な preview workflow が出るまでは skip する。 |
 | `~{${view.template} :: card}` のような template path expression | Diagnostic-only | dynamic template path は dependency target が static に分からないため skip する。 | non-fatal のまま維持し、推測 path は作らない。 |
@@ -64,11 +64,9 @@
 
 推奨サポート順:
 
-1. Same-template static references: `~{:: fragment(...)}` と `~{this :: fragment(...)}`。
-2. `replace` / `insert` / `include` と `data-th-*` の shared fragment reference attribute policy。
-3. story diagnostic surface での複数 parser diagnostics 表示。
-4. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
-5. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+1. story diagnostic surface での複数 parser diagnostics 表示。
+2. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
+3. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
 
 ### `th:each`
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -54,8 +54,8 @@ Status meanings:
 | `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | `data-th-*` variants are included in parsing and diagnostics where relevant. | Centralize the shared attribute policy across analyzers. |
 | `${dynamicRef}` as a fragment reference | Diagnostic-only | Dynamic references cannot be resolved statically and produce non-fatal diagnostics. | Keep diagnostic surfaced in story diagnostics. |
 | Malformed fragment expressions | Diagnostic-only | Malformed static references produce non-fatal diagnostics. | Improve source location for expression diagnostics when possible. |
-| Same-template references such as `~{:: header}` | Unsupported | `FragmentExpressionParser` currently requires a non-empty static template path. | High-value feature candidate. |
-| Same-template references such as `~{this :: header}` | Unsupported | `this` is currently rejected during static path normalization. | High-value feature candidate. |
+| Same-template references such as `~{:: header}` | Supported with current-template context | Static analyzers resolve the empty template path to the current template path. Parser calls without current-template context still fail closed. | Keep covered by parser, dependency, and model inference tests. |
+| Same-template references such as `~{this :: header}` | Supported with current-template context | Static analyzers resolve `this` to the current template path. Parser calls without current-template context still fail closed. | Keep covered by parser, dependency, and model inference tests. |
 | Selector-style references such as `~{template :: #header}` | Unsupported | CSS selector semantics are not normalized into a fragment name today. | Medium-value candidate; requires UI naming and matching rules. |
 | Whole-template references such as `~{template}` | Intentionally unsupported for fragment inference | Thymeleaf can render template-level references, but Thymeleaflet fragment dependency inference needs a selector. | Keep skipped unless a concrete preview workflow needs it. |
 | Template path expressions such as `~{${view.template} :: card}` | Diagnostic-only | Dynamic template paths are skipped because dependency targets are unknowable statically. | Keep non-fatal; do not infer speculative paths. |
@@ -64,11 +64,9 @@ Status meanings:
 
 Recommended support order:
 
-1. Same-template static references: `~{:: fragment(...)}` and `~{this :: fragment(...)}`.
-2. Shared fragment reference attribute policy for `replace` / `insert` / `include` and `data-th-*`.
-3. Multiple parser diagnostics on the story diagnostic surface.
-4. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
-5. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+1. Multiple parser diagnostics on the story diagnostic surface.
+2. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
+3. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
 
 ### `th:each`
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParser.java
@@ -15,7 +15,25 @@ public class FragmentExpressionParser {
         return parseWithDiagnostics(rawExpression).expression();
     }
 
+    public Optional<FragmentExpression> parse(String rawExpression, String currentTemplatePath) {
+        return parseWithDiagnostics(rawExpression, currentTemplatePath).expression();
+    }
+
     public FragmentExpressionParseResult parseWithDiagnostics(String rawExpression) {
+        return parseWithDiagnostics(rawExpression, Optional.empty());
+    }
+
+    public FragmentExpressionParseResult parseWithDiagnostics(String rawExpression, String currentTemplatePath) {
+        if (currentTemplatePath == null || currentTemplatePath.isBlank()) {
+            return parseWithDiagnostics(rawExpression, Optional.empty());
+        }
+        return parseWithDiagnostics(rawExpression, Optional.of(currentTemplatePath.trim()));
+    }
+
+    private FragmentExpressionParseResult parseWithDiagnostics(
+        String rawExpression,
+        Optional<String> currentTemplatePath
+    ) {
         if (rawExpression == null || rawExpression.isBlank()) {
             return FragmentExpressionParseResult.empty(
                 ParserDiagnostic.warning("FRAGMENT_EXPRESSION_EMPTY", "Fragment expression is empty")
@@ -37,7 +55,7 @@ public class FragmentExpressionParser {
         }
 
         int separatorIndex = findTopLevelFragmentSeparator(expression);
-        if (separatorIndex <= 0 || separatorIndex >= expression.length() - 2) {
+        if (separatorIndex < 0 || separatorIndex >= expression.length() - 2) {
             return FragmentExpressionParseResult.empty(
                 ParserDiagnostic.warning(
                     "FRAGMENT_EXPRESSION_MALFORMED",
@@ -46,7 +64,7 @@ public class FragmentExpressionParser {
             );
         }
 
-        String templatePath = normalizeTemplatePath(expression.substring(0, separatorIndex));
+        String templatePath = normalizeTemplatePath(expression.substring(0, separatorIndex), currentTemplatePath);
         Optional<FragmentSelector> selector = parseFragmentSelector(expression.substring(separatorIndex + 2));
         if (templatePath.isBlank() || selector.isEmpty()) {
             return FragmentExpressionParseResult.empty(
@@ -78,12 +96,15 @@ public class FragmentExpressionParser {
         return topLevelSyntaxScanner.findFirst(expression, "::").orElse(-1);
     }
 
-    private String normalizeTemplatePath(String rawTemplatePath) {
+    private String normalizeTemplatePath(String rawTemplatePath, Optional<String> currentTemplatePath) {
         String templatePath = unquote(rawTemplatePath.trim());
+        if (templatePath.isBlank() || templatePath.equals("this")) {
+            return currentTemplatePath.orElse("");
+        }
         if (templatePath.startsWith("/") && templatePath.length() > 1) {
             templatePath = templatePath.substring(1);
         }
-        if (templatePath.startsWith("#") || templatePath.startsWith("this") || templatePath.contains("${")) {
+        if (templatePath.startsWith("#") || templatePath.contains("${")) {
             return "";
         }
         return templatePath;

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -45,6 +45,21 @@ public class TemplateModelExpressionAnalyzer {
     }
 
     public TemplateInference analyze(String html, Set<String> parameterNames) {
+        return analyze(html, parameterNames, Optional.empty());
+    }
+
+    public TemplateInference analyze(String html, Set<String> parameterNames, String currentTemplatePath) {
+        if (currentTemplatePath == null || currentTemplatePath.isBlank()) {
+            return analyze(html, parameterNames, Optional.empty());
+        }
+        return analyze(html, parameterNames, Optional.of(currentTemplatePath.trim()));
+    }
+
+    private TemplateInference analyze(
+        String html,
+        Set<String> parameterNames,
+        Optional<String> currentTemplatePath
+    ) {
         StructuredTemplateParser.ParsedTemplate template = templateParser.parse(html);
         Set<String> excludedIdentifiers = new HashSet<>(parameterNames);
         excludedIdentifiers.addAll(extractLocalVariablesFromThWith(template));
@@ -52,7 +67,7 @@ public class TemplateModelExpressionAnalyzer {
         List<String> expressionSources = expressionSources(template);
         List<ModelPath> modelPaths = extractModelPathsFromSources(expressionSources, excludedIdentifiers);
         List<ModelPath> noArgMethodPaths = extractNoArgMethodPathsFromSources(expressionSources, excludedIdentifiers);
-        Map<String, Boolean> referencedTemplatePaths = extractReferencedTemplatePaths(template);
+        Map<String, Boolean> referencedTemplatePaths = extractReferencedTemplatePaths(template, currentTemplatePath);
         return new TemplateInference(modelPaths, loopVariablePaths, referencedTemplatePaths, noArgMethodPaths);
     }
 
@@ -193,13 +208,16 @@ public class TemplateModelExpressionAnalyzer {
         return loopVariables;
     }
 
-    private Map<String, Boolean> extractReferencedTemplatePaths(StructuredTemplateParser.ParsedTemplate template) {
+    private Map<String, Boolean> extractReferencedTemplatePaths(
+        StructuredTemplateParser.ParsedTemplate template,
+        Optional<String> currentTemplatePath
+    ) {
         Map<String, Boolean> referencedTemplatePaths = new LinkedHashMap<>();
         for (String raw : fragmentInsertionAttributeValues(template)) {
             if (raw == null || raw.isBlank()) {
                 continue;
             }
-            fragmentExpressionParser.parse(raw)
+            parseFragmentExpression(raw, currentTemplatePath)
                 .ifPresent(expression -> referencedTemplatePaths.merge(
                     expression.templatePath(),
                     requiresChildModelRecursion(expression),
@@ -207,6 +225,13 @@ public class TemplateModelExpressionAnalyzer {
                 ));
         }
         return referencedTemplatePaths;
+    }
+
+    private Optional<FragmentExpression> parseFragmentExpression(String raw, Optional<String> currentTemplatePath) {
+        if (currentTemplatePath.isPresent()) {
+            return fragmentExpressionParser.parse(raw, currentTemplatePath.orElseThrow());
+        }
+        return fragmentExpressionParser.parse(raw);
     }
 
     private List<String> fragmentInsertionAttributeValues(StructuredTemplateParser.ParsedTemplate template) {

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -101,7 +101,7 @@ public class FragmentDiscoveryService {
                 if (!template.templatePath().equals(templatePath)) {
                     continue;
                 }
-                return parserDiagnostics(template.content());
+                return parserDiagnostics(template.templatePath(), template.content());
             }
         } catch (IOException exception) {
             logger.warn("Failed to scan template diagnostics for {}: {}", templatePath, exception.getMessage());
@@ -109,7 +109,7 @@ public class FragmentDiscoveryService {
         return List.of();
     }
 
-    private List<ParserDiagnostic> parserDiagnostics(String templateContent) {
+    private List<ParserDiagnostic> parserDiagnostics(String templatePath, String templateContent) {
         StructuredTemplateParser.TemplateParseResult parseResult =
             structuredTemplateParser.parseWithDiagnostics(templateContent);
         List<ParserDiagnostic> diagnostics = new ArrayList<>(parseResult.diagnostics());
@@ -119,7 +119,9 @@ public class FragmentDiscoveryService {
                     || !FragmentReferenceAttributes.isReferenceAttribute(attribute.name())) {
                     continue;
                 }
-                diagnostics.addAll(fragmentExpressionParser.parseWithDiagnostics(attribute.value()).diagnostics());
+                diagnostics.addAll(
+                    fragmentExpressionParser.parseWithDiagnostics(attribute.value(), templatePath).diagnostics()
+                );
             }
         }
         return List.copyOf(diagnostics);

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -115,7 +115,7 @@ public class FragmentDependencyService implements FragmentDependencyPort {
 
             Map<String, DependencyComponent> dependencies = new LinkedHashMap<>();
             for (String expression : extractDependencyExpressions(targetElements)) {
-                Optional<DependencyComponent> component = parseDependency(expression);
+                Optional<DependencyComponent> component = parseDependency(expression, templatePath);
                 if (component.isEmpty()) {
                     continue;
                 }
@@ -147,8 +147,8 @@ public class FragmentDependencyService implements FragmentDependencyPort {
             .toList();
     }
 
-    private Optional<DependencyComponent> parseDependency(String expression) {
-        return fragmentExpressionParser.parse(expression)
+    private Optional<DependencyComponent> parseDependency(String expression, String currentTemplatePath) {
+        return fragmentExpressionParser.parse(expression, currentTemplatePath)
             .map(this::toDependencyComponent);
     }
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
@@ -69,7 +69,7 @@ public class FragmentModelInferenceService {
             return new InferredModel();
         }
 
-        TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames));
+        TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames), templatePath);
         InferredModel inferred = inference.toInferredModel();
         for (Map.Entry<String, Boolean> entry : inference.referencedTemplatePathsWithRecursionFlags().entrySet()) {
             String referencedTemplatePath = entry.getKey();
@@ -99,7 +99,7 @@ public class FragmentModelInferenceService {
             return new InferredModel();
         }
 
-        TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames));
+        TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames), templatePath);
         InferredModel inferred = new InferredModel();
         for (ModelPath methodPath : inference.noArgMethodPaths()) {
             if (methodPath.isEmpty()) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
@@ -43,11 +43,29 @@ class FragmentExpressionParserTest {
     }
 
     @Test
+    void parse_shouldResolveSameTemplateReferencesWhenCurrentTemplatePathIsProvided() {
+        FragmentExpression implicit = parser.parse("~{:: header(title=${view.title})}", "pages/dashboard")
+            .orElseThrow();
+        FragmentExpression explicit = parser.parse("~{this :: footer}", "pages/dashboard")
+            .orElseThrow();
+
+        assertThat(implicit.templatePath()).isEqualTo("pages/dashboard");
+        assertThat(implicit.fragmentName()).isEqualTo("header");
+        assertThat(implicit.arguments()).containsExactly("title=${view.title}");
+        assertThat(explicit.templatePath()).isEqualTo("pages/dashboard");
+        assertThat(explicit.fragmentName()).isEqualTo("footer");
+        assertThat(explicit.arguments()).isEmpty();
+        assertThat(explicit.hasArgumentList()).isFalse();
+    }
+
+    @Test
     void parse_shouldFailClosedForMalformedOrDynamicInput() {
         assertThat(parser.parse("${dynamicRef}")).isEmpty();
         assertThat(parser.parse("~{components/card}")).isEmpty();
         assertThat(parser.parse("~{components/card :: card(label=${view.title)}")).isEmpty();
         assertThat(parser.parse("~{${dynamicPath} :: card()}")).isEmpty();
+        assertThat(parser.parse("~{:: card()}")).isEmpty();
+        assertThat(parser.parse("~{this :: card()}")).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -76,6 +76,38 @@ class TemplateModelExpressionAnalyzerTest {
     }
 
     @Test
+    void shouldResolveSameTemplateReferencedTemplatePathsWhenCurrentTemplatePathIsProvided() {
+        String html = """
+            <section>
+              <th:block th:replace="~{:: header(title=${view.title})}"></th:block>
+              <th:block th:insert="~{this :: footer()}"></th:block>
+              <th:block th:replace="~{${dynamicPath} :: ignored()}"></th:block>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of(), "pages/dashboard");
+
+        assertThat(snapshot.referencedTemplatePaths())
+            .containsExactly("pages/dashboard");
+        assertThat(snapshot.referencedTemplatePathsWithRecursionFlags())
+            .containsEntry("pages/dashboard", true);
+    }
+
+    @Test
+    void shouldContinueSkippingSameTemplateReferencesWithoutCurrentTemplatePath() {
+        String html = """
+            <section>
+              <th:block th:replace="~{:: header(title=${view.title})}"></th:block>
+              <th:block th:insert="~{this :: footer()}"></th:block>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.referencedTemplatePaths()).isEmpty();
+    }
+
+    @Test
     void shouldExtractModelPathsAndReferencesFromDataThAttributes() {
         String html = """
             <section data-th-with="localText='hello'">

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
@@ -55,4 +55,25 @@ class FragmentDiscoveryServiceTemplateDiagnosticsTest {
                 assertThat(diagnostic.message()).contains("components/card");
             });
     }
+
+    @Test
+    void findTemplateParserDiagnostics_shouldAcceptSameTemplateFragmentReferences() throws IOException {
+        when(templateScanner.scanTemplates()).thenReturn(List.of(
+            new TemplateScanner.TemplateResource(
+                "components/profile",
+                """
+                    <section>
+                      <div th:replace="~{:: header(title=${view.title})}"></div>
+                      <div th:insert="~{this :: footer()}"></div>
+                    </section>
+                    """,
+                "classpath:/templates/components/profile.html"
+            )
+        ));
+
+        List<ParserDiagnostic> diagnostics = discoveryService.findTemplateParserDiagnostics("components/profile");
+
+        assertThat(diagnostics)
+            .noneSatisfy(diagnostic -> assertThat(diagnostic.code()).isEqualTo("FRAGMENT_EXPRESSION_MALFORMED"));
+    }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
@@ -74,6 +74,35 @@ class FragmentDependencyServiceTest {
     }
 
     @Test
+    void findDependencies_resolvesSameTemplateReferencesToCurrentTemplatePath() {
+        String html = """
+            <main>
+              <section th:fragment="shell(title)">
+                <div th:replace="~{:: header(title=${title})}"></div>
+                <div th:insert="~{this :: footer()}"></div>
+              </section>
+              <section th:fragment="header(title)">
+                <h2 th:text="${title}"></h2>
+              </section>
+              <section th:fragment="footer">
+                <p>Footer</p>
+              </section>
+            </main>
+            """;
+        FragmentDependencyService service = buildService("pages/shell", html);
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/shell", "shell");
+
+        assertThat(dependencies)
+            .extracting(FragmentDependencyService.DependencyComponent::key)
+            .containsExactly(
+                "pages/shell::header",
+                "pages/shell::footer"
+            );
+    }
+
+    @Test
     void findDependencies_usesSignatureParserAndDoesNotMatchMalformedFragmentDefinitions() {
         String html = """
             <main>


### PR DESCRIPTION
## Summary

- Resolve same-template fragment references (`~{:: fragment(...)}` and `~{this :: fragment(...)}`) when static analyzers have current template context
- Pass current template path through dependency extraction, model inference, and parser diagnostics
- Update the syntax support matrix in English and Japanese

## Verification

- `./mvnw -q -Dtest=FragmentExpressionParserTest,TemplateModelExpressionAnalyzerTest,FragmentDependencyServiceTest,FragmentDiscoveryServiceTemplateDiagnosticsTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes #526
