### PR TITLE
Support multiple parser diagnostics in story alerts

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -64,9 +64,10 @@
 
 推奨サポート順:
 
-1. story diagnostic surface での複数 parser diagnostics 表示。
-2. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
-3. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+1. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
+2. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+
+Story diagnostic surface は複数の non-fatal parser diagnostics を保持できます。YAML load diagnostic は単一 source の diagnostic として扱い、parser diagnostics はユーザー向けに要約しつつ developer detail は server-side に留めます。
 
 ### `th:each`
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -64,9 +64,10 @@ Status meanings:
 
 Recommended support order:
 
-1. Multiple parser diagnostics on the story diagnostic surface.
-2. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
-3. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+1. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
+2. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+
+Story diagnostic surfaces can carry multiple non-fatal parser diagnostics. YAML load diagnostics remain single-source diagnostics; parser diagnostics are summarized for users and retain developer details server-side.
 
 ### `th:each`
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/port/inbound/story/StoryRetrievalUseCase.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/port/inbound/story/StoryRetrievalUseCase.java
@@ -66,6 +66,21 @@ public interface StoryRetrievalUseCase {
     record StoryConfigurationDiagnostic(
         String code,
         String userSafeMessage,
-        String developerMessage
-    ) {}
+        String developerMessage,
+        List<DiagnosticItem> items
+    ) {
+        public StoryConfigurationDiagnostic(
+            String code,
+            String userSafeMessage,
+            String developerMessage
+        ) {
+            this(code, userSafeMessage, developerMessage, List.of());
+        }
+
+        public StoryConfigurationDiagnostic {
+            items = List.copyOf(items);
+        }
+    }
+
+    record DiagnosticItem(String code, String userSafeMessage) {}
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImpl.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * ストーリー取得専用ユースケース実装
@@ -129,17 +130,47 @@ public class StoryRetrievalUseCaseImpl implements StoryRetrievalUseCase {
         if (storyDiagnostic.isPresent()) {
             return storyDiagnostic;
         }
-        return fragmentCatalogPort.getTemplateParserDiagnostics(templatePath).stream()
-            .findFirst()
-            .map(this::toStoryConfigurationDiagnostic);
+        List<ParserDiagnostic> parserDiagnostics = fragmentCatalogPort.getTemplateParserDiagnostics(templatePath);
+        if (parserDiagnostics.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(toStoryConfigurationDiagnostic(parserDiagnostics));
     }
 
-    private StoryConfigurationDiagnostic toStoryConfigurationDiagnostic(ParserDiagnostic diagnostic) {
+    private StoryConfigurationDiagnostic toStoryConfigurationDiagnostic(List<ParserDiagnostic> diagnostics) {
+        if (diagnostics.size() == 1) {
+            ParserDiagnostic diagnostic = diagnostics.getFirst();
+            return new StoryConfigurationDiagnostic(
+                diagnostic.code(),
+                "Some template syntax was skipped while analyzing this story.",
+                diagnosticDeveloperMessage(diagnostic),
+                List.of(toDiagnosticItem(diagnostic))
+            );
+        }
         return new StoryConfigurationDiagnostic(
-            diagnostic.code(),
+            "TEMPLATE_PARSER_DIAGNOSTICS",
             "Some template syntax was skipped while analyzing this story.",
-            diagnosticDeveloperMessage(diagnostic)
+            diagnostics.stream()
+                .map(this::diagnosticDeveloperMessage)
+                .collect(Collectors.joining("\n")),
+            diagnostics.stream()
+                .map(this::toDiagnosticItem)
+                .toList()
         );
+    }
+
+    private StoryRetrievalUseCase.DiagnosticItem toDiagnosticItem(ParserDiagnostic diagnostic) {
+        return new StoryRetrievalUseCase.DiagnosticItem(
+            diagnostic.code(),
+            diagnosticUserSafeMessage(diagnostic)
+        );
+    }
+
+    private String diagnosticUserSafeMessage(ParserDiagnostic diagnostic) {
+        if (diagnostic.line() > 0 && diagnostic.column() > 0) {
+            return diagnostic.code() + " at line " + diagnostic.line() + ", column " + diagnostic.column();
+        }
+        return diagnostic.code();
     }
 
     private String diagnosticDeveloperMessage(ParserDiagnostic diagnostic) {

--- a/src/main/resources/templates/thymeleaflet/fragments/story-configuration-diagnostic.html
+++ b/src/main/resources/templates/thymeleaflet/fragments/story-configuration-diagnostic.html
@@ -21,6 +21,13 @@
     <div th:text="${resolvedDiagnostic.userSafeMessage}">
         Story YAML was found but could not be loaded.
     </div>
+    <ul th:if="${resolvedDiagnostic.items != null and !resolvedDiagnostic.items.isEmpty()}"
+        class="mt-2 list-disc space-y-1 pl-4">
+        <li th:each="item : ${resolvedDiagnostic.items}"
+            th:text="${item.userSafeMessage}">
+            TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED at line 3, column 12
+        </li>
+    </ul>
 </div>
 
 </body>

--- a/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
@@ -1,6 +1,7 @@
 package io.github.wamukat.thymeleaflet.application.service.story;
 
 import io.github.wamukat.thymeleaflet.application.port.outbound.StoryDataPort;
+import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryRetrievalUseCase.DiagnosticItem;
 import io.github.wamukat.thymeleaflet.application.port.inbound.story.StoryRetrievalUseCase.StoryConfigurationDiagnostic;
 import io.github.wamukat.thymeleaflet.application.port.outbound.FragmentCatalogPort;
 import io.github.wamukat.thymeleaflet.domain.model.FragmentStoryInfo;
@@ -168,6 +169,44 @@ class StoryRetrievalUseCaseImplTest {
                 .contains("Dynamic fragment reference was skipped in `th:replace`")
                 .contains("line 3")
                 .contains("column 12");
+            assertThat(mappedDiagnostic.items())
+                .extracting(DiagnosticItem::userSafeMessage)
+                .containsExactly("TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED at line 3, column 12");
+        });
+    }
+
+    @Test
+    void shouldMapMultipleParserDiagnosticsWhenStoryConfigurationHasNoDiagnostic() {
+        when(storyDataPort.getStoryConfigurationDiagnostic("components/profile")).thenReturn(Optional.empty());
+        when(fragmentCatalogPort.getTemplateParserDiagnostics("components/profile"))
+            .thenReturn(List.of(
+                new ParserDiagnostic(
+                    "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED",
+                    "Dynamic fragment reference was skipped in `th:replace`",
+                    3,
+                    12
+                ),
+                ParserDiagnostic.warning(
+                    "FRAGMENT_EXPRESSION_MALFORMED",
+                    "Fragment expression is missing a valid template/fragment separator: ~{components/card}"
+                )
+            ));
+
+        Optional<StoryConfigurationDiagnostic> diagnostic = useCase.getStoryConfigurationDiagnostic("components/profile");
+
+        assertThat(diagnostic).hasValueSatisfying(mappedDiagnostic -> {
+            assertThat(mappedDiagnostic.code()).isEqualTo("TEMPLATE_PARSER_DIAGNOSTICS");
+            assertThat(mappedDiagnostic.userSafeMessage())
+                .isEqualTo("Some template syntax was skipped while analyzing this story.");
+            assertThat(mappedDiagnostic.developerMessage())
+                .contains("Dynamic fragment reference was skipped in `th:replace`")
+                .contains("Fragment expression is missing a valid template/fragment separator");
+            assertThat(mappedDiagnostic.items())
+                .extracting(DiagnosticItem::userSafeMessage)
+                .containsExactly(
+                    "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED at line 3, column 12",
+                    "FRAGMENT_EXPRESSION_MALFORMED"
+                );
         });
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/StoryDiagnosticTemplateRenderingTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/rendering/StoryDiagnosticTemplateRenderingTest.java
@@ -53,6 +53,34 @@ class StoryDiagnosticTemplateRenderingTest {
     }
 
     @Test
+    void shouldRenderMultipleParserDiagnosticItemsWithoutDeveloperMessage() {
+        WebContext context = baseContext();
+        context.setVariable("storyConfigurationDiagnostic", new StoryRetrievalUseCase.StoryConfigurationDiagnostic(
+            "TEMPLATE_PARSER_DIAGNOSTICS",
+            "Some template syntax was skipped while analyzing this story.",
+            DEVELOPER_MESSAGE,
+            List.of(
+                new StoryRetrievalUseCase.DiagnosticItem(
+                    "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED",
+                    "TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED at line 3, column 12"
+                ),
+                new StoryRetrievalUseCase.DiagnosticItem(
+                    "FRAGMENT_EXPRESSION_MALFORMED",
+                    "FRAGMENT_EXPRESSION_MALFORMED"
+                )
+            )
+        ));
+
+        String html = templateEngine.process("thymeleaflet/test/story-diagnostic-host", context);
+
+        assertThat(html)
+            .contains("TEMPLATE_PARSER_DIAGNOSTICS")
+            .contains("TEMPLATE_DYNAMIC_FRAGMENT_REFERENCE_SKIPPED at line 3, column 12")
+            .contains("FRAGMENT_EXPRESSION_MALFORMED")
+            .doesNotContain(DEVELOPER_MESSAGE);
+    }
+
+    @Test
     void shouldUseStoryDiagnosticAlertFromMainContentAndStoryPreviewTemplates() {
         assertThat(resourceText("templates/thymeleaflet/fragments/main-content.html"))
             .contains("story-configuration-diagnostic :: alert(${storyConfigurationDiagnostic})")


### PR DESCRIPTION
## Summary

- Carry multiple non-fatal parser diagnostics through story diagnostic DTOs
- Render safe diagnostic item summaries in the story alert without exposing developer details
- Keep YAML diagnostics single-source and update parser support docs

## Verification

- `./mvnw -q -Dtest=StoryRetrievalUseCaseImplTest,StoryDiagnosticTemplateRenderingTest,FragmentDiscoveryServiceTemplateDiagnosticsTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes #527
