### PR TITLE
Harden parser comparison test support

### DIFF
--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplate.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplate.java
@@ -1,14 +1,50 @@
 package io.github.wamukat.thymeleaflet.testsupport.parser;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public record CandidateTemplate(List<CandidateElement> elements) {
+public record CandidateTemplate(List<CandidateElement> elements, boolean hasSourcePositions) {
+
+    public CandidateTemplate(List<CandidateElement> elements) {
+        this(elements, false);
+    }
+
     public CandidateTemplate {
         elements = List.copyOf(elements);
+        validateUniqueIndexes(elements);
+    }
+
+    private static boolean isDescendantOf(
+        CandidateElement candidate,
+        int rootIndex,
+        Map<Integer, CandidateElement> byIndex
+    ) {
+        int parentIndex = candidate.parentIndex();
+        while (parentIndex >= 0) {
+            if (parentIndex == rootIndex) {
+                return true;
+            }
+            CandidateElement parent = byIndex.get(parentIndex);
+            if (parent == null) {
+                return false;
+            }
+            parentIndex = parent.parentIndex();
+        }
+        return false;
+    }
+
+    private static void validateUniqueIndexes(List<CandidateElement> elements) {
+        Set<Integer> indexes = new HashSet<>();
+        for (CandidateElement element : elements) {
+            if (!indexes.add(element.index())) {
+                throw new IllegalArgumentException("Candidate element indexes must be unique: " + element.index());
+            }
+        }
     }
 
     public List<String> thymeleafAttributes() {
@@ -37,28 +73,5 @@ public record CandidateTemplate(List<CandidateElement> elements) {
         return elements.stream()
             .filter(isRootOrDescendant)
             .toList();
-    }
-
-    public boolean hasSourcePositions() {
-        return false;
-    }
-
-    private static boolean isDescendantOf(
-        CandidateElement candidate,
-        int rootIndex,
-        Map<Integer, CandidateElement> byIndex
-    ) {
-        int parentIndex = candidate.parentIndex();
-        while (parentIndex >= 0) {
-            if (parentIndex == rootIndex) {
-                return true;
-            }
-            CandidateElement parent = byIndex.get(parentIndex);
-            if (parent == null) {
-                return false;
-            }
-            parentIndex = parent.parentIndex();
-        }
-        return false;
     }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplateTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/testsupport/parser/CandidateTemplateTest.java
@@ -1,0 +1,62 @@
+package io.github.wamukat.thymeleaflet.testsupport.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CandidateTemplateTest {
+
+    @Test
+    void subtree_shouldKeepSiblingBoundaries() {
+        CandidateElement root = element("section", 0, -1, Map.of("th:fragment", "root"));
+        CandidateElement child = element("p", 1, 0, Map.of("th:text", "${view.root}"));
+        CandidateElement sibling = element("section", 2, -1, Map.of("th:fragment", "sibling"));
+        CandidateElement siblingChild = element("p", 3, 2, Map.of("th:text", "${view.sibling}"));
+        CandidateTemplate template = new CandidateTemplate(List.of(root, child, sibling, siblingChild));
+
+        assertThat(template.subtree(root))
+            .extracting(CandidateElement::index)
+            .containsExactly(0, 1);
+    }
+
+    @Test
+    void subtree_shouldStopAtBrokenParentChains() {
+        CandidateElement root = element("section", 0, -1, Map.of("th:fragment", "root"));
+        CandidateElement brokenDescendant = element("p", 1, 99, Map.of("th:text", "${view.broken}"));
+        CandidateTemplate template = new CandidateTemplate(List.of(root, brokenDescendant));
+
+        assertThat(template.subtree(root))
+            .extracting(CandidateElement::index)
+            .containsExactly(0);
+    }
+
+    @Test
+    void constructor_shouldRejectDuplicateCandidateIndexes() {
+        CandidateElement first = element("section", 0, -1, Map.of());
+        CandidateElement duplicate = element("p", 0, -1, Map.of());
+
+        assertThatThrownBy(() -> new CandidateTemplate(List.of(first, duplicate)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Candidate element indexes must be unique: 0");
+    }
+
+    @Test
+    void hasSourcePositions_shouldReflectCandidateCapability() {
+        CandidateElement root = element("section", 0, -1, Map.of());
+
+        assertThat(new CandidateTemplate(List.of(root)).hasSourcePositions()).isFalse();
+        assertThat(new CandidateTemplate(List.of(root), true).hasSourcePositions()).isTrue();
+    }
+
+    private static CandidateElement element(
+        String name,
+        int index,
+        int parentIndex,
+        Map<String, String> attributes
+    ) {
+        return new CandidateElement(name, attributes, index, parentIndex, parentIndex < 0 ? 0 : 1);
+    }
+}


### PR DESCRIPTION
## Summary
- make CandidateTemplate source-position capability explicit while preserving the jsoup default
- reject duplicate candidate element indexes at construction
- add tests for subtree boundaries, broken parent chains, duplicate indexes, and source-position capability

## Verification
- `./mvnw -q -Dtest=CandidateTemplateTest,HtmlParserAdapterComparisonTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local`
- `git diff --check`

Closes Kanban ticket #528.