### PR TITLE
Support selector-style fragment references

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -56,7 +56,7 @@
 | malformed fragment expressions | Diagnostic-only | malformed static reference は non-fatal diagnostic を出す。 | 可能なら expression diagnostic の source location を改善する。 |
 | `~{:: header}` のような same-template reference | Supported with current-template context | static analyzer は空の template path を現在の template path として解決する。current-template context なしの parser call は fail closed のまま。 | parser / dependency / model inference test で維持する。 |
 | `~{this :: header}` のような same-template reference | Supported with current-template context | static analyzer は `this` を現在の template path として解決する。current-template context なしの parser call は fail closed のまま。 | parser / dependency / model inference test で維持する。 |
-| `~{template :: #header}` のような selector-style reference | Unsupported | CSS selector semantics は fragment name として正規化していない。 | matching / UI 表示ルールを定義してから検討する。 |
+| `~{template :: #header}` や `~{template :: .card}` のような selector-style reference | Supported when deterministic | static dependency analysis は、`#id` / `.class` selector が valid な `th:fragment` または `data-th-fragment` 宣言を持つ要素に一意に一致する場合、その fragment 名へ解決する。曖昧な一致や fragment 宣言を持たない一致は non-fatal に skip する。 | parser / dependency test で維持する。 |
 | `~{template}` のような whole-template reference | Intentionally unsupported for fragment inference | Thymeleaf は template-level reference を rendering できるが、Thymeleaflet の fragment dependency inference には selector が必要。 | 具体的な preview workflow が出るまでは skip する。 |
 | `~{${view.template} :: card}` のような template path expression | Diagnostic-only | dynamic template path は dependency target が static に分からないため skip する。 | non-fatal のまま維持し、推測 path は作らない。 |
 | nested parentheses / quoted commas を含む fragment expression parameter | Supported | top-level split により nested expression と quote 内 separator を保持する。 | parser test で維持する。 |
@@ -64,8 +64,9 @@
 
 推奨サポート順:
 
-1. `#id` や `.class` の selector-style references。matching と UI 表示ルールを先に決める。
-2. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+1. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
+2. duplicate declaration parameter diagnostics。UI editing が parameter uniqueness に依存する前に進める。
+3. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
 
 Story diagnostic surface は複数の non-fatal parser diagnostics を保持できます。YAML load diagnostic は単一 source の diagnostic として扱い、parser diagnostics はユーザー向けに要約しつつ developer detail は server-side に留めます。
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -56,7 +56,7 @@ Status meanings:
 | Malformed fragment expressions | Diagnostic-only | Malformed static references produce non-fatal diagnostics. | Improve source location for expression diagnostics when possible. |
 | Same-template references such as `~{:: header}` | Supported with current-template context | Static analyzers resolve the empty template path to the current template path. Parser calls without current-template context still fail closed. | Keep covered by parser, dependency, and model inference tests. |
 | Same-template references such as `~{this :: header}` | Supported with current-template context | Static analyzers resolve `this` to the current template path. Parser calls without current-template context still fail closed. | Keep covered by parser, dependency, and model inference tests. |
-| Selector-style references such as `~{template :: #header}` | Unsupported | CSS selector semantics are not normalized into a fragment name today. | Medium-value candidate; requires UI naming and matching rules. |
+| Selector-style references such as `~{template :: #header}` or `~{template :: .card}` | Supported when deterministic | Static dependency analysis resolves `#id` and `.class` selectors to a target `th:fragment` or `data-th-fragment` declaration when exactly one matching element has a valid fragment declaration. Ambiguous or non-fragment matches are skipped non-fatally. | Keep covered by parser and dependency tests. |
 | Whole-template references such as `~{template}` | Intentionally unsupported for fragment inference | Thymeleaf can render template-level references, but Thymeleaflet fragment dependency inference needs a selector. | Keep skipped unless a concrete preview workflow needs it. |
 | Template path expressions such as `~{${view.template} :: card}` | Diagnostic-only | Dynamic template paths are skipped because dependency targets are unknowable statically. | Keep non-fatal; do not infer speculative paths. |
 | Fragment expression parameters with nested parentheses or quoted commas | Supported | Top-level splitting preserves nested expressions and quoted separators. | Keep covered by parser tests. |
@@ -64,8 +64,9 @@ Status meanings:
 
 Recommended support order:
 
-1. Selector-style references such as `#id` or `.class`, only after matching and UI display rules are specified.
-2. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+1. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
+2. Duplicate declaration parameter diagnostics, before UI editing relies on parameter uniqueness.
+3. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
 
 Story diagnostic surfaces can carry multiple non-fatal parser diagnostics. YAML load diagnostics remain single-source diagnostics; parser diagnostics are summarized for users and retain developer details server-side.
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyService.java
@@ -149,7 +149,93 @@ public class FragmentDependencyService implements FragmentDependencyPort {
 
     private Optional<DependencyComponent> parseDependency(String expression, String currentTemplatePath) {
         return fragmentExpressionParser.parse(expression, currentTemplatePath)
+            .flatMap(this::resolveSelectorStyleFragmentReference)
             .map(this::toDependencyComponent);
+    }
+
+    private Optional<FragmentExpression> resolveSelectorStyleFragmentReference(FragmentExpression expression) {
+        String selector = expression.fragmentName();
+        if (!isSelectorStyleFragmentName(selector)) {
+            return Optional.of(expression);
+        }
+        return resolveSelectorFragmentName(expression.templatePath(), selector)
+            .map(fragmentName -> FragmentExpression.of(
+                expression.templatePath(),
+                fragmentName,
+                expression.arguments(),
+                expression.hasArgumentList()
+            ));
+    }
+
+    private boolean isSelectorStyleFragmentName(String fragmentName) {
+        return fragmentName.startsWith("#") || fragmentName.startsWith(".");
+    }
+
+    private Optional<String> resolveSelectorFragmentName(String templatePath, String selector) {
+        Optional<StructuredTemplateParser.ParsedTemplate> template = parseTemplate(templatePath);
+        if (template.isEmpty()) {
+            return Optional.empty();
+        }
+        List<StructuredTemplateParser.TemplateElement> matchingElements = template.orElseThrow().elements().stream()
+            .filter(element -> matchesSelector(element, selector))
+            .toList();
+        if (matchingElements.size() != 1) {
+            logger.debug(
+                "Skipped selector-style fragment reference {} in {} because it matched {} elements",
+                selector,
+                templatePath,
+                matchingElements.size()
+            );
+            return Optional.empty();
+        }
+        List<String> matchingFragmentNames = matchingElements.stream()
+            .map(this::fragmentDefinition)
+            .flatMap(Optional::stream)
+            .map(this::parseFragmentName)
+            .flatMap(Optional::stream)
+            .toList();
+        if (matchingFragmentNames.size() != 1) {
+            logger.debug(
+                "Skipped selector-style fragment reference {} in {} because it matched {} fragment declarations",
+                selector,
+                templatePath,
+                matchingFragmentNames.size()
+            );
+            return Optional.empty();
+        }
+        return Optional.of(matchingFragmentNames.getFirst());
+    }
+
+    private Optional<StructuredTemplateParser.ParsedTemplate> parseTemplate(String templatePath) {
+        try {
+            Resource resource = resourcePathValidator.findTemplate(
+                templatePath,
+                storybookConfig.getResources().getTemplatePaths()
+            );
+            if (!resource.exists()) {
+                return Optional.empty();
+            }
+            String html = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return Optional.of(templateParser.parse(html));
+        } catch (Exception exception) {
+            logger.debug("Failed to resolve selector-style dependency target {}: {}", templatePath, exception.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private boolean matchesSelector(StructuredTemplateParser.TemplateElement element, String selector) {
+        if (selector.startsWith("#") && selector.length() > 1) {
+            return element.attributeValue("id")
+                .filter(selector.substring(1)::equals)
+                .isPresent();
+        }
+        if (selector.startsWith(".") && selector.length() > 1) {
+            String className = selector.substring(1);
+            return element.attributeValue("class")
+                .map(classes -> List.of(classes.trim().split("\\s+")).contains(className))
+                .orElse(false);
+        }
+        return false;
     }
 
     private DependencyComponent toDependencyComponent(FragmentExpression expression) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/FragmentExpressionParserTest.java
@@ -59,6 +59,23 @@ class FragmentExpressionParserTest {
     }
 
     @Test
+    void parse_shouldPreserveSelectorStyleFragmentReferences() {
+        FragmentExpression idSelector = parser.parse("~{components/header :: #site-header}")
+            .orElseThrow();
+        FragmentExpression classSelector = parser.parse("~{components/card :: .summary-card(title=${view.title})}")
+            .orElseThrow();
+
+        assertThat(idSelector.templatePath()).isEqualTo("components/header");
+        assertThat(idSelector.fragmentName()).isEqualTo("#site-header");
+        assertThat(idSelector.arguments()).isEmpty();
+        assertThat(idSelector.hasArgumentList()).isFalse();
+        assertThat(classSelector.templatePath()).isEqualTo("components/card");
+        assertThat(classSelector.fragmentName()).isEqualTo(".summary-card");
+        assertThat(classSelector.arguments()).containsExactly("title=${view.title}");
+        assertThat(classSelector.hasArgumentList()).isTrue();
+    }
+
+    @Test
     void parse_shouldFailClosedForMalformedOrDynamicInput() {
         assertThat(parser.parse("${dynamicRef}")).isEmpty();
         assertThat(parser.parse("~{components/card}")).isEmpty();

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -94,6 +94,24 @@ class TemplateModelExpressionAnalyzerTest {
     }
 
     @Test
+    void shouldExtractSelectorStyleReferencedTemplatePaths() {
+        String html = """
+            <section>
+              <th:block th:replace="~{components/header :: #site-header}"></th:block>
+              <th:block th:insert="~{components/card :: .summary-card(title=${view.title})}"></th:block>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.referencedTemplatePaths())
+            .contains("components/header", "components/card");
+        assertThat(snapshot.referencedTemplatePathsWithRecursionFlags())
+            .containsEntry("components/header", true)
+            .containsEntry("components/card", true);
+    }
+
+    @Test
     void shouldContinueSkippingSameTemplateReferencesWithoutCurrentTemplatePath() {
         String html = """
             <section>

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentDependencyServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.core.io.ByteArrayResource;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -103,6 +104,101 @@ class FragmentDependencyServiceTest {
     }
 
     @Test
+    void findDependencies_resolvesSelectorStyleReferencesToTargetFragmentDefinitions() {
+        String pageHtml = """
+            <main>
+              <section th:fragment="shell(title)">
+                <div th:replace="~{components/header :: #site-header(title=${title})}"></div>
+                <div th:insert="~{components/card :: .summary-card}"></div>
+              </section>
+            </main>
+            """;
+        String headerHtml = """
+            <header id="site-header" th:fragment="header(title)">
+              <h1 th:text="${title}"></h1>
+            </header>
+            """;
+        String cardHtml = """
+            <article class="summary-card featured" data-th-fragment="summaryCard">
+              <p>Summary</p>
+            </article>
+            """;
+        FragmentDependencyService service = buildService(
+            Map.of(
+                "pages/shell", pageHtml,
+                "components/header", headerHtml,
+                "components/card", cardHtml
+            )
+        );
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/shell", "shell");
+
+        assertThat(dependencies)
+            .extracting(FragmentDependencyService.DependencyComponent::key)
+            .containsExactly(
+                "components/header::header",
+                "components/card::summaryCard"
+            );
+    }
+
+    @Test
+    void findDependencies_skipsAmbiguousSelectorStyleReferences() {
+        String pageHtml = """
+            <main>
+              <section th:fragment="shell">
+                <div th:replace="~{components/cards :: .summary-card}"></div>
+              </section>
+            </main>
+            """;
+        String cardHtml = """
+            <main>
+              <article class="summary-card" th:fragment="firstCard"></article>
+              <article class="summary-card" th:fragment="secondCard"></article>
+            </main>
+            """;
+        FragmentDependencyService service = buildService(
+            Map.of(
+                "pages/shell", pageHtml,
+                "components/cards", cardHtml
+            )
+        );
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/shell", "shell");
+
+        assertThat(dependencies).isEmpty();
+    }
+
+    @Test
+    void findDependencies_skipsSelectorStyleReferencesWhenNonFragmentMatchesMakeSelectorAmbiguous() {
+        String pageHtml = """
+            <main>
+              <section th:fragment="shell">
+                <div th:replace="~{components/cards :: .summary-card}"></div>
+              </section>
+            </main>
+            """;
+        String cardHtml = """
+            <main>
+              <article class="summary-card" th:fragment="card"></article>
+              <article class="summary-card">Decorative duplicate</article>
+            </main>
+            """;
+        FragmentDependencyService service = buildService(
+            Map.of(
+                "pages/shell", pageHtml,
+                "components/cards", cardHtml
+            )
+        );
+
+        List<FragmentDependencyService.DependencyComponent> dependencies =
+            service.findDependencies("pages/shell", "shell");
+
+        assertThat(dependencies).isEmpty();
+    }
+
+    @Test
     void findDependencies_usesSignatureParserAndDoesNotMatchMalformedFragmentDefinitions() {
         String html = """
             <main>
@@ -145,11 +241,17 @@ class FragmentDependencyServiceTest {
     }
 
     private FragmentDependencyService buildService(String templatePath, String html) {
+        return buildService(Map.of(templatePath, html));
+    }
+
+    private FragmentDependencyService buildService(Map<String, String> templates) {
         StorybookProperties properties = new StorybookProperties();
         ResolvedStorybookConfig config = ResolvedStorybookConfig.from(properties, false);
         ThymeleafletCacheManager cacheManager = new ThymeleafletCacheManager(config);
-        when(resourcePathValidator.findTemplate(eq(templatePath), eq(config.getResources().getTemplatePaths())))
-            .thenReturn(resource(html));
+        templates.forEach((templatePath, html) ->
+            when(resourcePathValidator.findTemplate(eq(templatePath), eq(config.getResources().getTemplatePaths())))
+                .thenReturn(resource(html))
+        );
         return new FragmentDependencyService(config, resourcePathValidator, cacheManager);
     }
 


### PR DESCRIPTION
## Summary
- resolve deterministic `#id` and `.class` selector-style fragment references to target fragment declarations during dependency extraction
- preserve selector references in the expression parser and static template-path inference
- skip ambiguous selector matches, including mixed fragment/non-fragment matches, non-fatally
- update the syntax support matrix in English and Japanese docs

## Verification
- `./mvnw -q -Dtest=FragmentExpressionParserTest,TemplateModelExpressionAnalyzerTest,FragmentDependencyServiceTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local`
- `git diff --check`

Closes Kanban ticket #530.