### PR TITLE
Map named fragment arguments for inference

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -49,7 +49,7 @@
 | `~{'components/card' :: card(title='Ready')}` | Supported | quote 付き template path と literal argument をサポートする。literal-only call は child model recursion を skip する。 | parser corpus で維持する。 |
 | `~{"components/card" :: content}` | Supported | double quote 付き template path をサポートする。 | parser test で維持する。 |
 | `~{components/topbar :: topbar()}` | Supported | no-argument call を正規化し、child model requirements へ再帰しない。 | no-arg preprocessing test で維持する。 |
-| named call arguments, e.g. `card(title=${view.title})` | Supported as raw arguments | argument name/value は raw segment として保持する。declaration parameter への意味的 mapping は未実施。 | story value ordering が必要とする場合のみ semantic mapping を検討する。 |
+| named call arguments, e.g. `card(title=${view.title})` | Supported with declaration-aware inference | argument name/value は raw segment として保持する。model inference では、call argument がすべて named で target declaration を取得できる場合に declaration parameter と照合する。positional と named の mixed call は conservative な raw behavior のまま扱う。 | analyzer / model inference test で維持する。 |
 | `th:replace`, `th:insert`, `th:include` | Supported | static fragment expression を解析する。unsupported / dynamic reference は non-fatal に skip する。 | analyzer 間で shared attribute policy を集約する。 |
 | `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | 関連箇所では `data-th-*` variant も parsing / diagnostics 対象に含める。 | analyzer 間で shared attribute policy を集約する。 |
 | fragment reference としての `${dynamicRef}` | Diagnostic-only | dynamic reference は static に解決できないため non-fatal diagnostic を出す。 | story diagnostics への surfaced 状態を維持する。 |
@@ -64,9 +64,8 @@
 
 推奨サポート順:
 
-1. Semantic named-argument mapping。story value ordering が declaration-aware binding を必要とする場合のみ進める。
-2. duplicate declaration parameter diagnostics。UI editing が parameter uniqueness に依存する前に進める。
-3. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
+1. duplicate declaration parameter diagnostics。UI editing が parameter uniqueness に依存する前に進める。
+2. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
 
 Story diagnostic surface は複数の non-fatal parser diagnostics を保持できます。YAML load diagnostic は単一 source の diagnostic として扱い、parser diagnostics はユーザー向けに要約しつつ developer detail は server-side に留めます。
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -49,7 +49,7 @@ Status meanings:
 | `~{'components/card' :: card(title='Ready')}` | Supported | Quoted template paths and literal arguments are supported. Literal-only calls skip child model recursion. | Keep covered by parser corpus. |
 | `~{"components/card" :: content}` | Supported | Double-quoted template paths are supported. | Keep covered by parser tests. |
 | `~{components/topbar :: topbar()}` | Supported | No-argument calls are normalized and do not recurse into child model requirements. | Keep covered by no-arg preprocessing tests. |
-| Named call arguments, for example `card(title=${view.title})` | Supported as raw arguments | Argument names and values are preserved as raw segments; they are not mapped to declaration parameters semantically. | Consider semantic named-argument mapping only if preview value ordering needs it. |
+| Named call arguments, for example `card(title=${view.title})` | Supported with declaration-aware inference | Argument names and values are preserved as raw segments. During model inference, named arguments are matched to target declaration parameters when all call arguments are named and the target declaration is available. Mixed positional/named calls keep the conservative raw behavior. | Keep covered by analyzer and model inference tests. |
 | `th:replace`, `th:insert`, `th:include` | Supported | Static fragment expressions are analyzed. Unsupported or dynamic references are skipped non-fatally. | Centralize the shared attribute policy across analyzers. |
 | `data-th-replace`, `data-th-insert`, `data-th-include` | Supported | `data-th-*` variants are included in parsing and diagnostics where relevant. | Centralize the shared attribute policy across analyzers. |
 | `${dynamicRef}` as a fragment reference | Diagnostic-only | Dynamic references cannot be resolved statically and produce non-fatal diagnostics. | Keep diagnostic surfaced in story diagnostics. |
@@ -64,9 +64,8 @@ Status meanings:
 
 Recommended support order:
 
-1. Semantic named-argument mapping, only if story value ordering needs declaration-aware argument binding.
-2. Duplicate declaration parameter diagnostics, before UI editing relies on parameter uniqueness.
-3. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
+1. Duplicate declaration parameter diagnostics, before UI editing relies on parameter uniqueness.
+2. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
 
 Story diagnostic surfaces can carry multiple non-fatal parser diagnostics. YAML load diagnostics remain single-source diagnostics; parser diagnostics are summarized for users and retain developer details server-side.
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
@@ -14,6 +14,7 @@ public final class TemplateInference {
     private final Map<String, ModelPath> loopVariablePaths;
     private final Map<String, Boolean> referencedTemplatePaths;
     private final List<ModelPath> noArgMethodPaths;
+    private final List<ReferencedFragment> referencedFragments;
 
     public TemplateInference(
         List<ModelPath> modelPaths,
@@ -21,10 +22,21 @@ public final class TemplateInference {
         Map<String, Boolean> referencedTemplatePaths,
         List<ModelPath> noArgMethodPaths
     ) {
+        this(modelPaths, loopVariablePaths, referencedTemplatePaths, noArgMethodPaths, List.of());
+    }
+
+    public TemplateInference(
+        List<ModelPath> modelPaths,
+        Map<String, ModelPath> loopVariablePaths,
+        Map<String, Boolean> referencedTemplatePaths,
+        List<ModelPath> noArgMethodPaths,
+        List<ReferencedFragment> referencedFragments
+    ) {
         this.modelPaths = List.copyOf(modelPaths);
         this.loopVariablePaths = Map.copyOf(new LinkedHashMap<>(loopVariablePaths));
         this.referencedTemplatePaths = Map.copyOf(new LinkedHashMap<>(referencedTemplatePaths));
         this.noArgMethodPaths = List.copyOf(noArgMethodPaths);
+        this.referencedFragments = List.copyOf(referencedFragments);
     }
 
     public List<ModelPath> modelPaths() {
@@ -47,6 +59,10 @@ public final class TemplateInference {
         return noArgMethodPaths;
     }
 
+    public List<ReferencedFragment> referencedFragments() {
+        return referencedFragments;
+    }
+
     public InferredModel toInferredModel() {
         InferredModel inferred = new InferredModel();
         for (ModelPath modelPath : modelPaths) {
@@ -61,5 +77,19 @@ public final class TemplateInference {
             inferred.putPath(modelPath.segments(), modelPath.inferSampleValue());
         }
         return inferred;
+    }
+
+    public record ReferencedFragment(
+        String templatePath,
+        String fragmentName,
+        List<String> arguments,
+        boolean hasArgumentList,
+        boolean requiresChildModelRecursion
+    ) {
+        public ReferencedFragment {
+            templatePath = templatePath.trim();
+            fragmentName = fragmentName.trim();
+            arguments = List.copyOf(arguments);
+        }
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -67,8 +67,16 @@ public class TemplateModelExpressionAnalyzer {
         List<String> expressionSources = expressionSources(template);
         List<ModelPath> modelPaths = extractModelPathsFromSources(expressionSources, excludedIdentifiers);
         List<ModelPath> noArgMethodPaths = extractNoArgMethodPathsFromSources(expressionSources, excludedIdentifiers);
-        Map<String, Boolean> referencedTemplatePaths = extractReferencedTemplatePaths(template, currentTemplatePath);
-        return new TemplateInference(modelPaths, loopVariablePaths, referencedTemplatePaths, noArgMethodPaths);
+        List<TemplateInference.ReferencedFragment> referencedFragments =
+            extractReferencedFragments(template, currentTemplatePath);
+        Map<String, Boolean> referencedTemplatePaths = referencedTemplatePaths(referencedFragments);
+        return new TemplateInference(
+            modelPaths,
+            loopVariablePaths,
+            referencedTemplatePaths,
+            noArgMethodPaths,
+            referencedFragments
+        );
     }
 
     private List<ModelPath> extractModelPathsFromSources(List<String> sources, Set<String> excludedIdentifiers) {
@@ -208,21 +216,36 @@ public class TemplateModelExpressionAnalyzer {
         return loopVariables;
     }
 
-    private Map<String, Boolean> extractReferencedTemplatePaths(
+    private List<TemplateInference.ReferencedFragment> extractReferencedFragments(
         StructuredTemplateParser.ParsedTemplate template,
         Optional<String> currentTemplatePath
     ) {
-        Map<String, Boolean> referencedTemplatePaths = new LinkedHashMap<>();
+        List<TemplateInference.ReferencedFragment> referencedFragments = new ArrayList<>();
         for (String raw : fragmentInsertionAttributeValues(template)) {
             if (raw == null || raw.isBlank()) {
                 continue;
             }
             parseFragmentExpression(raw, currentTemplatePath)
-                .ifPresent(expression -> referencedTemplatePaths.merge(
+                .map(expression -> new TemplateInference.ReferencedFragment(
                     expression.templatePath(),
-                    requiresChildModelRecursion(expression),
-                    (left, right) -> left || right
-                ));
+                    expression.fragmentName(),
+                    expression.arguments(),
+                    expression.hasArgumentList(),
+                    requiresChildModelRecursion(expression)
+                ))
+                .ifPresent(referencedFragments::add);
+        }
+        return referencedFragments;
+    }
+
+    private Map<String, Boolean> referencedTemplatePaths(List<TemplateInference.ReferencedFragment> referencedFragments) {
+        Map<String, Boolean> referencedTemplatePaths = new LinkedHashMap<>();
+        for (TemplateInference.ReferencedFragment reference : referencedFragments) {
+            referencedTemplatePaths.merge(
+                reference.templatePath(),
+                reference.requiresChildModelRecursion(),
+                (left, right) -> left || right
+            );
         }
         return referencedTemplatePaths;
     }

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceService.java
@@ -3,16 +3,21 @@ package io.github.wamukat.thymeleaflet.infrastructure.web.service;
 import io.github.wamukat.thymeleaflet.domain.model.InferredModel;
 import io.github.wamukat.thymeleaflet.domain.model.ModelPath;
 import io.github.wamukat.thymeleaflet.domain.model.TemplateInference;
+import io.github.wamukat.thymeleaflet.domain.service.StructuredTemplateParser;
 import io.github.wamukat.thymeleaflet.domain.service.TemplateModelExpressionAnalyzer;
+import io.github.wamukat.thymeleaflet.domain.service.TopLevelSyntaxScanner;
+import io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery.FragmentSignatureParser;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -25,6 +30,9 @@ public class FragmentModelInferenceService {
 
     private final ResourceLoader resourceLoader;
     private final TemplateModelExpressionAnalyzer expressionAnalyzer;
+    private final StructuredTemplateParser templateParser = new StructuredTemplateParser();
+    private final FragmentSignatureParser fragmentSignatureParser = new FragmentSignatureParser();
+    private final TopLevelSyntaxScanner topLevelSyntaxScanner = new TopLevelSyntaxScanner();
 
     public FragmentModelInferenceService(
         ResourceLoader resourceLoader,
@@ -71,16 +79,19 @@ public class FragmentModelInferenceService {
 
         TemplateInference inference = expressionAnalyzer.analyze(html, new HashSet<>(parameterNames), templatePath);
         InferredModel inferred = inference.toInferredModel();
-        for (Map.Entry<String, Boolean> entry : inference.referencedTemplatePathsWithRecursionFlags().entrySet()) {
-            String referencedTemplatePath = entry.getKey();
-            boolean requiresRecursion = entry.getValue();
-            if (!requiresRecursion) {
+        for (TemplateInference.ReferencedFragment reference : inference.referencedFragments()) {
+            if (!reference.requiresChildModelRecursion()) {
                 continue;
             }
+            String referencedTemplatePath = reference.templatePath();
             if (referencedTemplatePath.equals(templatePath)) {
                 continue;
             }
-            InferredModel child = inferModelRecursive(referencedTemplatePath, List.of(), visitedTemplatePaths);
+            InferredModel child = inferModelRecursive(
+                referencedTemplatePath,
+                mappedChildParameterNames(reference),
+                visitedTemplatePaths
+            );
             inferred.merge(child);
         }
         return inferred;
@@ -113,20 +124,106 @@ public class FragmentModelInferenceService {
             inferred.putPath(methodPath.segments(), methodPath.inferSampleValue());
         }
 
-        for (Map.Entry<String, Boolean> entry : inference.referencedTemplatePathsWithRecursionFlags().entrySet()) {
-            String referencedTemplatePath = entry.getKey();
-            boolean requiresRecursion = entry.getValue();
-            if (!requiresRecursion) {
+        for (TemplateInference.ReferencedFragment reference : inference.referencedFragments()) {
+            if (!reference.requiresChildModelRecursion()) {
                 continue;
             }
+            String referencedTemplatePath = reference.templatePath();
             if (referencedTemplatePath.equals(templatePath)) {
                 continue;
             }
-            InferredModel child = inferMethodReturnCandidatesRecursive(referencedTemplatePath, List.of(), visitedTemplatePaths);
+            InferredModel child = inferMethodReturnCandidatesRecursive(
+                referencedTemplatePath,
+                mappedChildParameterNames(reference),
+                visitedTemplatePaths
+            );
             inferred.merge(child);
         }
 
         return inferred;
+    }
+
+    private List<String> mappedChildParameterNames(TemplateInference.ReferencedFragment reference) {
+        if (!reference.hasArgumentList() || reference.arguments().isEmpty()) {
+            return List.of();
+        }
+        List<String> argumentNames = namedArgumentNames(reference.arguments());
+        if (argumentNames.isEmpty()) {
+            return List.of();
+        }
+        List<String> declarationParameters = fragmentParameterNames(reference.templatePath(), reference.fragmentName());
+        if (!declarationParameters.containsAll(argumentNames)) {
+            return List.of();
+        }
+        return argumentNames;
+    }
+
+    private List<String> namedArgumentNames(List<String> arguments) {
+        List<String> argumentNames = new ArrayList<>();
+        for (String argument : arguments) {
+            Optional<String> name = namedArgumentName(argument);
+            if (name.isEmpty()) {
+                return List.of();
+            }
+            argumentNames.add(name.orElseThrow());
+        }
+        return argumentNames;
+    }
+
+    private Optional<String> namedArgumentName(String argument) {
+        var assignIndex = topLevelSyntaxScanner.findFirst(argument, "=");
+        if (assignIndex.isEmpty() || assignIndex.orElseThrow() <= 0) {
+            return Optional.empty();
+        }
+        String candidate = argument.substring(0, assignIndex.orElseThrow()).trim();
+        if (!isIdentifier(candidate)) {
+            return Optional.empty();
+        }
+        return Optional.of(candidate);
+    }
+
+    private boolean isIdentifier(String candidate) {
+        if (candidate.isBlank() || !Character.isLetterOrDigit(candidate.charAt(0))) {
+            return false;
+        }
+        for (int index = 1; index < candidate.length(); index++) {
+            char current = candidate.charAt(index);
+            if (!Character.isLetterOrDigit(current) && current != '_' && current != '-') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<String> fragmentParameterNames(String templatePath, String fragmentName) {
+        String html = readTemplateSource(templatePath);
+        if (html.isEmpty()) {
+            return List.of();
+        }
+        StructuredTemplateParser.ParsedTemplate parsedTemplate = templateParser.parse(html);
+        for (StructuredTemplateParser.TemplateElement element : parsedTemplate.elements()) {
+            Optional<List<String>> parameters = parseFragmentParameters(element, fragmentName);
+            if (parameters.isPresent()) {
+                return parameters.orElseThrow();
+            }
+        }
+        return List.of();
+    }
+
+    private Optional<List<String>> parseFragmentParameters(
+        StructuredTemplateParser.TemplateElement element,
+        String fragmentName
+    ) {
+        Optional<String> definition = element.attributeValue("th:fragment")
+            .or(() -> element.attributeValue("data-th-fragment"));
+        if (definition.isEmpty()) {
+            return Optional.empty();
+        }
+        FragmentSignatureParser.ParseResult result = fragmentSignatureParser.parse(definition.orElseThrow());
+        if (result instanceof FragmentSignatureParser.ParseSuccess success && success.fragmentName().equals(fragmentName)) {
+            return Optional.of(success.parameters());
+        }
+        return Optional.empty();
     }
 
     private String readTemplateSource(String templatePath) {

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -112,6 +112,26 @@ class TemplateModelExpressionAnalyzerTest {
     }
 
     @Test
+    void shouldPreserveReferencedFragmentRawArguments() {
+        String html = """
+            <section>
+              <th:block th:replace="~{components/card :: card(variant=${view.variant}, title='Ready')}"></th:block>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.referencedFragments()).singleElement()
+            .satisfies(reference -> {
+                assertThat(reference.templatePath()).isEqualTo("components/card");
+                assertThat(reference.fragmentName()).isEqualTo("card");
+                assertThat(reference.arguments()).containsExactly("variant=${view.variant}", "title='Ready'");
+                assertThat(reference.hasArgumentList()).isTrue();
+                assertThat(reference.requiresChildModelRecursion()).isTrue();
+            });
+    }
+
+    @Test
     void shouldContinueSkippingSameTemplateReferencesWithoutCurrentTemplatePath() {
         String html = """
             <section>

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
@@ -109,4 +109,43 @@ class FragmentModelInferenceServiceTest {
 
         assertThat(inferred).doesNotContainKeys("label", "variant");
     }
+
+    @Test
+    void shouldMapNamedFragmentArgumentsToChildDeclarationParameters() {
+        Map<String, Object> inferred = service.inferModel(
+            "fragments/named-child-reference-inference-sample",
+            "namedChildReferenceInferenceSample",
+            List.of()
+        );
+
+        assertThat(inferred).containsKeys("view", "childOnly");
+        assertThat(inferred).doesNotContainKeys("title", "variant");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> view = (Map<String, Object>) Objects.requireNonNull(inferred.get("view"));
+        assertThat(view).containsKeys("title", "variant");
+    }
+
+    @Test
+    void shouldAvoidDeclarationAwareMappingForMixedFragmentArguments() {
+        Map<String, Object> inferred = service.inferModel(
+            "fragments/mixed-child-reference-inference-sample",
+            "mixedChildReferenceInferenceSample",
+            List.of()
+        );
+
+        assertThat(inferred).containsKeys("view", "title", "variant", "childOnly");
+    }
+
+    @Test
+    void shouldMapNamedFragmentArgumentsWhenInferringMethodReturnCandidates() {
+        Map<String, Object> inferred = service.inferMethodReturnCandidates(
+            "fragments/named-child-reference-inference-sample",
+            "namedChildReferenceInferenceSample",
+            List.of()
+        );
+
+        assertThat(inferred).containsKey("childMethodOnly");
+        assertThat(inferred).doesNotContainKeys("title", "variant");
+    }
 }

--- a/src/test/resources/templates/components/named-child-inference-sample.html
+++ b/src/test/resources/templates/components/named-child-inference-sample.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<article th:fragment="child(title, variant)">
+    <h2 th:text="${title}"></h2>
+    <strong th:text="${title.trim()}"></strong>
+    <p th:text="${variant}"></p>
+    <span th:text="${childOnly}"></span>
+    <small th:text="${childMethodOnly.trim()}"></small>
+</article>
+</body>
+</html>

--- a/src/test/resources/templates/fragments/mixed-child-reference-inference-sample.html
+++ b/src/test/resources/templates/fragments/mixed-child-reference-inference-sample.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<section th:fragment="mixedChildReferenceInferenceSample">
+    <th:block th:replace="~{components/named-child-inference-sample :: child(${view.title}, variant=${view.variant})}"></th:block>
+</section>
+</body>
+</html>

--- a/src/test/resources/templates/fragments/named-child-reference-inference-sample.html
+++ b/src/test/resources/templates/fragments/named-child-reference-inference-sample.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<section th:fragment="namedChildReferenceInferenceSample">
+    <th:block th:replace="~{components/named-child-inference-sample :: child(variant=${view.variant}, title=${view.title})}"></th:block>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Preserve raw fragment reference argument segments in `TemplateInference`
- Map all-named fragment call arguments to target declaration parameters during child model recursion
- Keep mixed positional/named calls conservative and update syntax support docs
- Add focused model and method-return inference tests for named and mixed argument calls

## Verification
- `./mvnw -q -Dtest=FragmentModelInferenceServiceTest,TemplateModelExpressionAnalyzerTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes Kanban ticket #531.
