### PR TITLE
Diagnose duplicate fragment parameters

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -42,7 +42,7 @@
 | `th:fragment="profileCard()"` | Supported | 空の parameter list を no-argument fragment として正規化する。 | declaration parser test で維持する。 |
 | `th:fragment="profileCard(name, age)"` | Supported | identifier parameter を宣言順で保持する。 | declaration parser test で維持する。 |
 | `data-th-fragment="profileCard(name)"` | Supported | discovery では `data-th-fragment` を `th:fragment` と同様に扱う。 | discovery test で維持する。 |
-| duplicate declaration parameters | Supported as-is | duplicate name は現在 declaration order のまま保持し、uniqueness diagnostic はまだ出していない。 | UI editing が uniqueness に依存する前に直接 diagnostic を追加する。 |
+| duplicate declaration parameters | Diagnostic-only | duplicate name は declaration order のまま保持し、`FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER` を source location 付きの non-fatal story diagnostic として表示する。 | parser / template diagnostic test で維持する。 |
 | declaration parameter defaults / assignment syntax | Unsupported | `profileCard(name='x')` のような declaration 側 syntax は v1 UI support set の外。 | 実テンプレートで必要になった場合のみ再検討する。 |
 | non-identifier declaration names / parameters | Unsupported | Thymeleaf が受け付ける範囲より、Thymeleaflet の正規化出力は狭く保つ。 | 推測で正規化せず diagnostic として扱う。 |
 | `~{components/card :: card(title=${view.title})}` | Supported | static template path、selector、argument list を dependency / model inference に利用する。 | `FragmentExpressionParserTest` で維持する。 |
@@ -64,8 +64,7 @@
 
 推奨サポート順:
 
-1. duplicate declaration parameter diagnostics。UI editing が parameter uniqueness に依存する前に進める。
-2. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
+1. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
 
 Story diagnostic surface は複数の non-fatal parser diagnostics を保持できます。YAML load diagnostic は単一 source の diagnostic として扱い、parser diagnostics はユーザー向けに要約しつつ developer detail は server-side に留めます。
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -42,7 +42,7 @@ Status meanings:
 | `th:fragment="profileCard()"` | Supported | Empty parameter list is normalized as a no-argument fragment. | Keep covered by declaration parser tests. |
 | `th:fragment="profileCard(name, age)"` | Supported | Identifier parameters are preserved in declaration order. | Keep covered by declaration parser tests. |
 | `data-th-fragment="profileCard(name)"` | Supported | Discovery treats `data-th-fragment` like `th:fragment`. | Keep covered by discovery tests. |
-| Duplicate declaration parameters | Supported as-is | Duplicate names are currently preserved in declaration order; no uniqueness diagnostic is emitted yet. | Add a direct diagnostic if UI editing starts relying on uniqueness. |
+| Duplicate declaration parameters | Diagnostic-only | Duplicate names are preserved in declaration order, and `FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER` is surfaced as a non-fatal story diagnostic with source location when available. | Keep covered by parser and template diagnostic tests. |
 | Declaration parameter defaults or assignment syntax | Unsupported | Declaration-side syntax such as `profileCard(name='x')` is outside the v1 UI support set. | Revisit only if real templates need it. |
 | Non-identifier declaration names or parameters | Unsupported | Thymeleaf-compatible parsing may accept more than the UI support set; Thymeleaflet keeps normalized output narrow. | Keep as diagnostic rather than normalizing speculatively. |
 | `~{components/card :: card(title=${view.title})}` | Supported | Static template path, selector, and argument list are parsed for dependency and model inference. | Keep covered by `FragmentExpressionParserTest`. |
@@ -64,8 +64,7 @@ Status meanings:
 
 Recommended support order:
 
-1. Duplicate declaration parameter diagnostics, before UI editing relies on parameter uniqueness.
-2. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
+1. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
 
 Story diagnostic surfaces can carry multiple non-fatal parser diagnostics. YAML load diagnostics remain single-source diagnostics; parser diagnostics are summarized for users and retain developer details server-side.
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryService.java
@@ -115,6 +115,9 @@ public class FragmentDiscoveryService {
         List<ParserDiagnostic> diagnostics = new ArrayList<>(parseResult.diagnostics());
         for (StructuredTemplateParser.TemplateElement element : parseResult.parsedTemplate().elements()) {
             for (StructuredTemplateParser.TemplateAttribute attribute : element.attributes()) {
+                if (attribute.hasValue() && isFragmentDeclarationAttribute(attribute.name())) {
+                    diagnostics.addAll(fragmentDeclarationDiagnostics(attribute));
+                }
                 if (!attribute.hasValue()
                     || !FragmentReferenceAttributes.isReferenceAttribute(attribute.name())) {
                     continue;
@@ -125,6 +128,25 @@ public class FragmentDiscoveryService {
             }
         }
         return List.copyOf(diagnostics);
+    }
+
+    private boolean isFragmentDeclarationAttribute(String attributeName) {
+        return attributeName.equals("th:fragment") || attributeName.equals("data-th-fragment");
+    }
+
+    private List<ParserDiagnostic> fragmentDeclarationDiagnostics(StructuredTemplateParser.TemplateAttribute attribute) {
+        FragmentSignatureParser.ParseResult parseResult = fragmentSignatureParser.parse(attribute.value());
+        if (!(parseResult instanceof FragmentSignatureParser.ParseSuccess parseSuccess)) {
+            return List.of();
+        }
+        return parseSuccess.diagnostics().stream()
+            .map(diagnostic -> new ParserDiagnostic(
+                diagnostic.code(),
+                diagnostic.message(),
+                attribute.line(),
+                attribute.column()
+            ))
+            .toList();
     }
     
     /**

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentSignatureParser.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentSignatureParser.java
@@ -1,12 +1,16 @@
 package io.github.wamukat.thymeleaflet.infrastructure.adapter.discovery;
 
+import io.github.wamukat.thymeleaflet.domain.service.ParserDiagnostic;
 import org.thymeleaf.standard.expression.FragmentSignature;
 import org.thymeleaf.standard.expression.FragmentSignatureUtils;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Component
 public class FragmentSignatureParser {
@@ -48,7 +52,22 @@ public class FragmentSignatureParser {
             }
         }
 
-        return new ParseSuccess(fragmentName, parameters);
+        return new ParseSuccess(fragmentName, parameters, duplicateParameterDiagnostics(fragmentName, parameters));
+    }
+
+    private List<ParserDiagnostic> duplicateParameterDiagnostics(String fragmentName, List<String> parameters) {
+        Set<String> seen = new HashSet<>();
+        List<ParserDiagnostic> diagnostics = new ArrayList<>();
+        for (String parameter : parameters) {
+            if (seen.add(parameter)) {
+                continue;
+            }
+            diagnostics.add(ParserDiagnostic.warning(
+                "FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER",
+                "Fragment `" + fragmentName + "` declares duplicate parameter `" + parameter + "`."
+            ));
+        }
+        return diagnostics;
     }
 
     private static boolean isValidIdentifier(String value) {
@@ -103,10 +122,19 @@ public class FragmentSignatureParser {
     public sealed interface ParseResult permits ParseSuccess, ParseError {
     }
 
-    public record ParseSuccess(String fragmentName, List<String> parameters) implements ParseResult {
+    public record ParseSuccess(
+        String fragmentName,
+        List<String> parameters,
+        List<ParserDiagnostic> diagnostics
+    ) implements ParseResult {
+        public ParseSuccess(String fragmentName, List<String> parameters) {
+            this(fragmentName, parameters, List.of());
+        }
+
         public ParseSuccess {
             fragmentName = fragmentName.trim();
             parameters = List.copyOf(parameters);
+            diagnostics = List.copyOf(diagnostics);
         }
     }
 

--- a/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/application/service/story/StoryRetrievalUseCaseImplTest.java
@@ -176,6 +176,31 @@ class StoryRetrievalUseCaseImplTest {
     }
 
     @Test
+    void shouldMapDuplicateFragmentParameterDiagnosticWhenStoryConfigurationHasNoDiagnostic() {
+        when(storyDataPort.getStoryConfigurationDiagnostic("components/profile")).thenReturn(Optional.empty());
+        when(fragmentCatalogPort.getTemplateParserDiagnostics("components/profile"))
+            .thenReturn(List.of(new ParserDiagnostic(
+                "FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER",
+                "Fragment `profileCard` declares duplicate parameter `name`.",
+                2,
+                14
+            )));
+
+        Optional<StoryConfigurationDiagnostic> diagnostic = useCase.getStoryConfigurationDiagnostic("components/profile");
+
+        assertThat(diagnostic).hasValueSatisfying(mappedDiagnostic -> {
+            assertThat(mappedDiagnostic.code()).isEqualTo("FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER");
+            assertThat(mappedDiagnostic.developerMessage())
+                .contains("duplicate parameter `name`")
+                .contains("line 2")
+                .contains("column 14");
+            assertThat(mappedDiagnostic.items())
+                .extracting(DiagnosticItem::userSafeMessage)
+                .containsExactly("FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER at line 2, column 14");
+        });
+    }
+
+    @Test
     void shouldMapMultipleParserDiagnosticsWhenStoryConfigurationHasNoDiagnostic() {
         when(storyDataPort.getStoryConfigurationDiagnostic("components/profile")).thenReturn(Optional.empty());
         when(fragmentCatalogPort.getTemplateParserDiagnostics("components/profile"))

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentDiscoveryServiceTemplateDiagnosticsTest.java
@@ -76,4 +76,70 @@ class FragmentDiscoveryServiceTemplateDiagnosticsTest {
         assertThat(diagnostics)
             .noneSatisfy(diagnostic -> assertThat(diagnostic.code()).isEqualTo("FRAGMENT_EXPRESSION_MALFORMED"));
     }
+
+    @Test
+    void findTemplateParserDiagnostics_shouldReturnDuplicateFragmentParameterWarnings() throws IOException {
+        FragmentDiscoveryService service = new FragmentDiscoveryService(
+            templateScanner,
+            mock(FragmentDefinitionParser.class),
+            mock(FragmentDomainService.class),
+            new FragmentSignatureParser(),
+            new StructuredTemplateParser(),
+            new FragmentExpressionParser(),
+            mock(ThymeleafletCacheManager.class)
+        );
+        when(templateScanner.scanTemplates()).thenReturn(List.of(
+            new TemplateScanner.TemplateResource(
+                "components/profile",
+                """
+                    <section th:fragment="profileCard(name, age, name)">
+                    </section>
+                    """,
+                "classpath:/templates/components/profile.html"
+            )
+        ));
+
+        List<ParserDiagnostic> diagnostics = service.findTemplateParserDiagnostics("components/profile");
+
+        assertThat(diagnostics).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER");
+                assertThat(diagnostic.message()).contains("profileCard").contains("name");
+                assertThat(diagnostic.line()).isGreaterThan(0);
+                assertThat(diagnostic.column()).isGreaterThan(0);
+            });
+    }
+
+    @Test
+    void findTemplateParserDiagnostics_shouldReturnDuplicateDataThFragmentParameterWarnings() throws IOException {
+        FragmentDiscoveryService service = new FragmentDiscoveryService(
+            templateScanner,
+            mock(FragmentDefinitionParser.class),
+            mock(FragmentDomainService.class),
+            new FragmentSignatureParser(),
+            new StructuredTemplateParser(),
+            new FragmentExpressionParser(),
+            mock(ThymeleafletCacheManager.class)
+        );
+        when(templateScanner.scanTemplates()).thenReturn(List.of(
+            new TemplateScanner.TemplateResource(
+                "components/profile",
+                """
+                    <section data-th-fragment="profileCard(name, name)">
+                    </section>
+                    """,
+                "classpath:/templates/components/profile.html"
+            )
+        ));
+
+        List<ParserDiagnostic> diagnostics = service.findTemplateParserDiagnostics("components/profile");
+
+        assertThat(diagnostics).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER");
+                assertThat(diagnostic.message()).contains("profileCard").contains("name");
+                assertThat(diagnostic.line()).isGreaterThan(0);
+                assertThat(diagnostic.column()).isGreaterThan(0);
+            });
+    }
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentSignatureParserTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/adapter/discovery/FragmentSignatureParserTest.java
@@ -44,6 +44,21 @@ class FragmentSignatureParserTest {
     }
 
     @Test
+    @DisplayName("duplicate parameters are preserved with diagnostics")
+    void preservesDuplicateParametersWithDiagnostics() {
+        FragmentSignatureParser.ParseResult result = parser.parse("profileCard(name, age, name)");
+
+        assertThat(result).isInstanceOf(FragmentSignatureParser.ParseSuccess.class);
+        FragmentSignatureParser.ParseSuccess success = (FragmentSignatureParser.ParseSuccess) result;
+        assertThat(success.parameters()).containsExactly("name", "age", "name");
+        assertThat(success.diagnostics()).singleElement()
+            .satisfies(diagnostic -> {
+                assertThat(diagnostic.code()).isEqualTo("FRAGMENT_SIGNATURE_DUPLICATE_PARAMETER");
+                assertThat(diagnostic.message()).contains("name");
+            });
+    }
+
+    @Test
     @DisplayName("whitespace around signature is normalized")
     void parsesWithWhitespace() {
         FragmentSignatureParser.ParseResult result = parser.parse(" profileCard ( name , age ) ");


### PR DESCRIPTION
## Summary
- Preserve duplicate fragment declaration parameters while attaching non-fatal parser diagnostics
- Surface duplicate parameter diagnostics through template/story diagnostics with source location
- Cover both `th:fragment` and `data-th-fragment` declaration diagnostics
- Update the syntax support matrix for duplicate declaration parameters

## Verification
- `./mvnw -q -Dtest=FragmentSignatureParserTest,FragmentDiscoveryServiceTemplateDiagnosticsTest,StoryRetrievalUseCaseImplTest test`
- `./mvnw -q -Dtest=FragmentDiscoveryServiceTemplateDiagnosticsTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes Kanban ticket #532.
