### PR TITLE
Infer stable bracket expression paths

### DIFF
--- a/docs/template-parsing.ja.md
+++ b/docs/template-parsing.ja.md
@@ -18,7 +18,7 @@
    - 識別子、文字列、dot、safe-navigation dot、括弧、bracket、utility prefix、operator を token 化します。
    - プレビューのモデル推論に必要な式のサブセットからモデルパスを抽出します。
    - `#temporals` などの utility 名、`T(java.time.LocalDate)` などの static class 参照、パラメータ、local alias、Thymeleaf の予約語はモデルパスにしません。
-   - `view.map[key]` のような未対応 bracket 式は fail closed にします。安定した prefix は残しますが、dynamic key はモデルパスとして推論しません。
+   - `view.items[0].name`、`view['display-name']`、`view[display-name]` のような安定した bracket 式を推論し、`view.map[key]` のような dynamic key は fail closed にします。
 4. `JavaDocAnalyzer`
    - HTML コメント内の JavaDoc 形式から `@param`、`@model`、`@fragment`、`@example`、`@background` を解析します。
    - `@example` markup には `StructuredTemplateParser` を使い、`th:replace` と `data-th-replace` の例をテンプレート本体と同じ属性解析ルールで扱います。
@@ -64,7 +64,7 @@
 
 推奨サポート順:
 
-1. stable bracket expression inference。dynamic key は推測せず、indexed path など安定したケースに限定する。
+1. bracket inference は、推測を含まない model shape を定義できる安定した bracket 形式に限定して拡張する。
 
 Story diagnostic surface は複数の non-fatal parser diagnostics を保持できます。YAML load diagnostic は単一 source の diagnostic として扱い、parser diagnostics はユーザー向けに要約しつつ developer detail は server-side に留めます。
 
@@ -130,6 +130,14 @@ fragment call が空引数、または全引数が literal の場合は、子モ
 ```
 
 推論されるパスは `view.profile.name`、`item.publishedAt`、`view.cutoffDate`、`view.display-name` です。
+
+安定した indexed bracket 式は list 形の sample data として推論します。
+
+```html
+<span th:text="${view.items[0].name}"></span>
+```
+
+これは `view.items[] -> name` として扱います。`view.map[key].label` のような dynamic key は引き続き安定した prefix `view.map` までで止めます。
 
 Analyzer は Thymeleaf や Spring EL を完全評価しません。未対応構文は、推測で壊れたパスを作らず、無視するか安定した prefix に縮退します。
 

--- a/docs/template-parsing.md
+++ b/docs/template-parsing.md
@@ -18,7 +18,7 @@ Template parsing is intentionally split into small layers:
    - Tokenizes identifiers, strings, dots, safe-navigation dots, parentheses, brackets, utility prefixes, and operators.
    - Extracts model paths from the expression subset needed by preview model inference.
    - Ignores utility object names such as `#temporals`, static class references such as `T(java.time.LocalDate)`, parameters, local aliases, and Thymeleaf reserved words.
-   - Fails closed for unsupported bracket expressions such as `view.map[key]`; the stable prefix is kept, but dynamic keys are not inferred as model paths.
+   - Infers stable bracket expressions such as `view.items[0].name`, `view['display-name']`, and `view[display-name]`, while failing closed for dynamic keys such as `view.map[key]`.
 4. `JavaDocAnalyzer`
    - Parses JavaDoc-style HTML comments for `@param`, `@model`, `@fragment`, `@example`, and `@background`.
    - Uses `StructuredTemplateParser` for `@example` markup so `th:replace` and `data-th-replace` examples follow the same attribute parsing rules as templates.
@@ -64,7 +64,7 @@ Status meanings:
 
 Recommended support order:
 
-1. Stable bracket expression inference for indexed paths, while keeping dynamic keys non-speculative.
+1. Extend bracket inference only when a new stable bracket form has a non-speculative model shape.
 
 Story diagnostic surfaces can carry multiple non-fatal parser diagnostics. YAML load diagnostics remain single-source diagnostics; parser diagnostics are summarized for users and retain developer details server-side.
 
@@ -130,6 +130,14 @@ Model path inference is intentionally conservative. Supported examples include:
 ```
 
 The inferred paths are `view.profile.name`, `item.publishedAt`, `view.cutoffDate`, and `view.display-name`.
+
+Stable indexed bracket expressions infer list-shaped sample data:
+
+```html
+<span th:text="${view.items[0].name}"></span>
+```
+
+This is modeled as `view.items[] -> name`. Dynamic keys such as `view.map[key].label` still stop at the stable prefix `view.map`.
 
 The analyzer does not try to fully evaluate Thymeleaf or Spring EL. Unsupported constructs are ignored or reduced to a stable prefix instead of producing speculative paths.
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/InferredModel.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/InferredModel.java
@@ -10,10 +10,17 @@ import java.util.Map;
  */
 public final class InferredModel {
 
+    private static final String INDEX_SEGMENT = "[]";
+
     private final LinkedHashMap<String, Object> values = new LinkedHashMap<>();
 
     public void putPath(List<String> path, Object leafValue) {
         if (path.isEmpty()) {
+            return;
+        }
+        int indexSegment = path.indexOf(INDEX_SEGMENT);
+        if (indexSegment > 0) {
+            putLoopPath(path.subList(0, indexSegment), path.subList(indexSegment + 1, path.size()), leafValue);
             return;
         }
         if (path.size() == 1) {
@@ -142,6 +149,11 @@ public final class InferredModel {
         if (path.isEmpty()) {
             return;
         }
+        int indexSegment = path.indexOf(INDEX_SEGMENT);
+        if (indexSegment > 0) {
+            putNestedListPath(root, path, indexSegment, leafValue);
+            return;
+        }
         if (path.size() == 1) {
             root.putIfAbsent(path.getFirst(), leafValue);
             return;
@@ -161,5 +173,28 @@ public final class InferredModel {
             current = casted;
         }
         current.putIfAbsent(path.get(path.size() - 1), leafValue);
+    }
+
+    private void putNestedListPath(Map<String, Object> root, List<String> path, int indexSegment, Object leafValue) {
+        Map<String, Object> current = root;
+        for (int i = 0; i < indexSegment - 1; i++) {
+            String segment = path.get(i);
+            Object child = current.get(segment);
+            if (!(child instanceof Map<?, ?> childMap)) {
+                Map<String, Object> created = new LinkedHashMap<>();
+                current.put(segment, created);
+                current = created;
+                continue;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> casted = (Map<String, Object>) childMap;
+            current = casted;
+        }
+        List<Object> list = ensureListValue(current, path.get(indexSegment - 1));
+        if (indexSegment >= path.size() - 1) {
+            return;
+        }
+        Map<String, Object> firstItem = ensureFirstListMap(list);
+        putNestedMapPath(firstItem, path.subList(indexSegment + 1, path.size()), leafValue);
     }
 }

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/model/TemplateInference.java
@@ -10,6 +10,8 @@ import java.util.Set;
  */
 public final class TemplateInference {
 
+    private static final String INDEX_SEGMENT = "[]";
+
     private final List<ModelPath> modelPaths;
     private final Map<String, ModelPath> loopVariablePaths;
     private final Map<String, Boolean> referencedTemplatePaths;
@@ -70,6 +72,17 @@ public final class TemplateInference {
                 continue;
             }
             ModelPath loopPath = loopVariablePaths.get(modelPath.root());
+            int indexSegment = modelPath.segments().indexOf(INDEX_SEGMENT);
+            if (indexSegment > 0) {
+                List<String> iterablePath = loopPath == null
+                    ? modelPath.segments().subList(0, indexSegment)
+                    : loopPath.segments();
+                List<String> itemSubPath = loopPath == null
+                    ? indexedItemSubPath(modelPath, indexSegment)
+                    : modelPath.segments().subList(1, modelPath.segments().size());
+                inferred.putLoopPath(iterablePath, itemSubPath, modelPath.inferSampleValue());
+                continue;
+            }
             if (loopPath != null) {
                 inferred.putLoopPath(loopPath.segments(), modelPath.subPathWithoutRoot(), modelPath.inferSampleValue());
                 continue;
@@ -77,6 +90,13 @@ public final class TemplateInference {
             inferred.putPath(modelPath.segments(), modelPath.inferSampleValue());
         }
         return inferred;
+    }
+
+    private List<String> indexedItemSubPath(ModelPath modelPath, int indexSegment) {
+        if (indexSegment >= modelPath.segments().size() - 1) {
+            return List.of();
+        }
+        return modelPath.segments().subList(indexSegment + 1, modelPath.segments().size());
     }
 
     public record ReferencedFragment(

--- a/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzer.java
@@ -458,6 +458,7 @@ public class TemplateModelExpressionAnalyzer {
 
     private enum ExpressionTokenType {
         IDENTIFIER,
+        NUMBER,
         STRING,
         DOT,
         SAFE_DOT,
@@ -498,6 +499,15 @@ public class TemplateModelExpressionAnalyzer {
                         index++;
                     }
                     tokens.add(new ExpressionToken(ExpressionTokenType.IDENTIFIER, expression.substring(start, index)));
+                    continue;
+                }
+                if (Character.isDigit(current)) {
+                    int start = index;
+                    index++;
+                    while (index < expression.length() && Character.isDigit(expression.charAt(index))) {
+                        index++;
+                    }
+                    tokens.add(new ExpressionToken(ExpressionTokenType.NUMBER, expression.substring(start, index)));
                     continue;
                 }
                 if (current == '\'' || current == '"') {
@@ -612,9 +622,9 @@ public class TemplateModelExpressionAnalyzer {
 
             while (index < tokens.size()) {
                 if (isAt(ExpressionTokenType.LEFT_BRACKET)) {
-                    Optional<String> bracketKey = parseBracketKey();
-                    if (bracketKey.isPresent()) {
-                        segments.add(bracketKey.orElseThrow());
+                    Optional<String> bracketSegment = parseBracketSegment();
+                    if (bracketSegment.isPresent()) {
+                        segments.add(bracketSegment.orElseThrow());
                         continue;
                     }
                     skipUnsupportedBracket();
@@ -653,13 +663,28 @@ public class TemplateModelExpressionAnalyzer {
             return Optional.of(segments);
         }
 
-        private Optional<String> parseBracketKey() {
+        private Optional<String> parseBracketSegment() {
             if (isAt(index, ExpressionTokenType.LEFT_BRACKET)
                 && isAt(index + 1, ExpressionTokenType.STRING)
                 && isAt(index + 2, ExpressionTokenType.RIGHT_BRACKET)) {
                 String key = tokens.get(index + 1).text();
                 index += 3;
                 return Optional.of(key);
+            }
+            if (isAt(index, ExpressionTokenType.LEFT_BRACKET)
+                && isAt(index + 1, ExpressionTokenType.NUMBER)
+                && isAt(index + 2, ExpressionTokenType.RIGHT_BRACKET)) {
+                index += 3;
+                return Optional.of("[]");
+            }
+            if (isAt(index, ExpressionTokenType.LEFT_BRACKET)
+                && isAt(index + 1, ExpressionTokenType.IDENTIFIER)
+                && isAt(index + 2, ExpressionTokenType.RIGHT_BRACKET)) {
+                String key = tokens.get(index + 1).text();
+                if (key.contains("-")) {
+                    index += 3;
+                    return Optional.of(key);
+                }
             }
             return Optional.empty();
         }

--- a/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/domain/service/TemplateModelExpressionAnalyzerTest.java
@@ -303,9 +303,11 @@ class TemplateModelExpressionAnalyzerTest {
     }
 
     @Test
-    void shouldFailClosedForUnsupportedBracketAccessors() {
+    void shouldInferStableBracketAccessorsAndFailClosedForDynamicKeys() {
         String html = """
             <section>
+              <span th:text="${view['display-name']}"></span>
+              <span th:text="${view[display-name]}"></span>
               <span th:text="${view.map[key].label}"></span>
               <span th:text="${view.items[0].name}"></span>
             </section>
@@ -314,11 +316,48 @@ class TemplateModelExpressionAnalyzerTest {
         TemplateInference snapshot = analyzer.analyze(html, Set.of());
 
         assertThat(snapshot.modelPaths())
+            .contains(ModelPath.of(List.of("view", "display-name")))
             .contains(ModelPath.of(List.of("view", "map")))
-            .contains(ModelPath.of(List.of("view", "items")))
+            .contains(ModelPath.of(List.of("view", "items", "[]", "name")))
             .doesNotContain(ModelPath.of(List.of("key")))
             .doesNotContain(ModelPath.of(List.of("view", "map", "label")))
             .doesNotContain(ModelPath.of(List.of("view", "items", "name")));
+    }
+
+    @Test
+    void shouldBuildListModelForStableIndexedBracketAccessors() {
+        String html = """
+            <section>
+              <span th:text="${view.items[0].name}"></span>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.toInferredModel().toMap())
+            .containsEntry("view", java.util.Map.of(
+                "items", java.util.List.of(java.util.Map.of("name", "Sample name"))
+            ));
+    }
+
+    @Test
+    void shouldBuildNestedListModelForIndexedBracketAccessorsInsideLoopAliases() {
+        String html = """
+            <section>
+              <article th:each="item : ${view.items}">
+                <span th:text="${item.tags[0].label}"></span>
+              </article>
+            </section>
+            """;
+
+        TemplateInference snapshot = analyzer.analyze(html, Set.of());
+
+        assertThat(snapshot.toInferredModel().toMap())
+            .containsEntry("view", java.util.Map.of(
+                "items", java.util.List.of(java.util.Map.of(
+                    "tags", java.util.List.of(java.util.Map.of("label", "Sample label"))
+                ))
+            ));
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/web/service/FragmentModelInferenceServiceTest.java
@@ -148,4 +148,17 @@ class FragmentModelInferenceServiceTest {
         assertThat(inferred).containsKey("childMethodOnly");
         assertThat(inferred).doesNotContainKeys("title", "variant");
     }
+
+    @Test
+    void shouldInferIndexedNoArgMethodReturnCandidatesAsListModel() {
+        Map<String, Object> inferred = service.inferMethodReturnCandidates(
+            "fragments/indexed-method-inference-sample",
+            "indexedMethodInferenceSample",
+            List.of()
+        );
+
+        assertThat(inferred).containsEntry("view", Map.of(
+            "items", List.of(Map.of("hasVisible", false))
+        ));
+    }
 }

--- a/src/test/resources/templates/fragments/indexed-method-inference-sample.html
+++ b/src/test/resources/templates/fragments/indexed-method-inference-sample.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<section th:fragment="indexedMethodInferenceSample">
+    <span th:if="${view.items[0].hasVisible()}">Visible</span>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Infer stable numeric bracket expressions as list-shaped model data
- Preserve literal map-key bracket inference and keep dynamic keys conservative
- Handle indexed paths in normal model inference, loop aliases, and no-arg method fallback candidates
- Update parser syntax docs for stable bracket inference

## Verification
- `./mvnw -q -Dtest=TemplateModelExpressionAnalyzerTest test`
- `./mvnw -q -Dtest=TemplateModelExpressionAnalyzerTest,FragmentModelInferenceServiceTest test`
- `npm run test:workflow`
- `./mvnw test -q`
- `npm run test:e2e:local` (10 tests)
- `git diff --check`

Closes Kanban ticket #533.
