### PR TITLE
Prepare release 0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.25] - 2026-05-05
+
+- Added
+  - Added a sample full-page `appLayout` fragment and story to cover layouts declared on the `<html>` root element.
+- Fixed
+  - Supported previews for complete HTML documents returned by `<html th:fragment="...">` layout fragments by preserving the rendered document head/body and injecting only preview resources plus height reporting instead of wrapping the document as a partial snippet. (#185)
+- Test
+  - Added E2E regression coverage ensuring full-page layout fragments render without preview warnings and without `#preview-root` wrapper injection.
+- Build
+  - Updated Maven project, sample app, and README dependency examples to `0.2.25`.
+
+### Issues
+
+- #185 `<html>` root fragments returning full HTML documents fail preview loading
+
 ## [0.2.24] - 2026-05-04
 
 - Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.24</version>
+  <version>0.2.25</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.24")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.25")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.24</version>
+  <version>0.2.25</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.24")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.25")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.24</version>
+    <version>0.2.25</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.24</version>
+    <version>0.2.25</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.24</version>
+            <version>0.2.25</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

- Prepare release `0.2.25`
- Update Maven/sample versions and README dependency examples
- Add changelog entry for full-page `<html th:fragment>` preview support

## Verification

- `./mvnw test -q`
- `npm run test:e2e:local`
- GitHub Actions will run on this PR

Closes: N/A
