### PR TITLE
Prepare release 0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.26] - 2026-05-05
+
+- Added
+  - Added story preview metadata for default viewport selection via `preview.viewport`, so responsive-only fragments can open in the intended viewport without manual switching. (#183)
+  - Added story preview minimum height support via `preview.minHeight`, so fixed and sticky fragments can remain visible even when they do not contribute normal document flow height. (#184)
+  - Added sample stories for responsive viewport defaults, fixed toolbar previews, and rendered error text content.
+- Fixed
+  - Stopped treating rendered HTML text containing `システムエラー` or `System Error` as a preview load failure when the render response itself succeeds. (#152)
+- Docs
+  - Documented `preview.viewport` and `preview.minHeight` story metadata in English and Japanese story documentation.
+- Test
+  - Added YAML loading and E2E coverage for story preview viewport/min-height metadata and legitimate rendered error text content.
+- Build
+  - Updated Maven project, sample app, and README dependency examples to `0.2.26`.
+
+### Issues
+
+- #152 Preview falsely reports load failure when rendered HTML contains `システムエラー` or `System Error`
+- #183 Story default viewport metadata
+- #184 Story preview minimum height metadata for fixed/sticky fragments
+
 ## [0.2.25] - 2026-05-05
 
 - Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.25</version>
+  <version>0.2.26</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.25")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.26")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.25</version>
+  <version>0.2.26</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.25")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.26")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.25</version>
+    <version>0.2.26</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.25</version>
+    <version>0.2.26</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.25</version>
+            <version>0.2.26</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

Prepare release 0.2.26.

- Update root and sample Maven versions to 0.2.26
- Update README dependency examples in English and Japanese
- Add 0.2.26 changelog entries for preview metadata and rendered error text fixes

Closes: N/A

## Release Notes

### Added
- `preview.viewport` story metadata for default viewport selection, helping responsive-only fragments open at the intended size.
- `preview.minHeight` story metadata for fixed and sticky fragments that do not contribute normal document-flow height.
- Sample stories for responsive viewport defaults, fixed toolbar previews, and rendered error text content.

### Fixed
- Preview loading no longer fails just because successful rendered HTML contains `システムエラー` or `System Error`.

### Docs/Test
- Documented the new story preview metadata in English and Japanese.
- Added YAML loading and E2E coverage for the new preview metadata and rendered error text regression.

## Verification

- `./mvnw test -q` passed
- `npm run test:e2e:local` passed: 17/17
- Confirmed no sample app remains listening on port 6006
