### PR TITLE
Release 0.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.27] - 2026-05-06
+
+- Changed
+  - Improved the Story values panel so model objects are displayed as readable pretty-printed JSON instead of Java `Map.toString()` output. (#191)
+  - Applied the same object formatting path to object-valued fragment parameters and method return candidates in Story values. (#191)
+- Build
+  - Enforced `@NullMarked` package coverage and redundant null-check cleanup for stronger NullAway/JSpecify integration. (#111)
+  - Updated Maven project, sample app, and README dependency examples to `0.2.27`.
+- Test
+  - Added formatter unit coverage and E2E regression coverage to keep Story values object display readable. (#191)
+
+### Issues
+
+- PR #111 Add NullAway/JSpecify package coverage and documentation
+- PR #191 Improve Story values object formatting
+
 ## [0.2.26] - 2026-05-05
 
 - Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.26</version>
+  <version>0.2.27</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.26")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.27")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.26</version>
+  <version>0.2.27</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.26")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.27")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.26</version>
+    <version>0.2.27</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.26</version>
+    <version>0.2.27</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.26</version>
+            <version>0.2.27</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- Prepare 0.2.27 release version updates for Maven, sample app, and README dependency examples.
- Update CHANGELOG.md with Story values formatting and NullAway/JSpecify build quality changes.

## Release Notes
- Story values now render model objects as pretty-printed JSON instead of Java Map.toString output.
- Object-valued parameters and method return candidates use the same readable formatting path.
- NullAway/JSpecify package coverage and redundant null-check cleanup are included from PR #111.

## Verification
- ./mvnw test -q
- npm run test:e2e:local
- Confirmed port 6006 is not listening after E2E shutdown.

Closes: N/A
