### PR TITLE
Enable thymeleaflet auto permit by default

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -111,9 +111,8 @@ thymeleaflet:
 - `cache.preload` は起動時にキャッシュをウォームアップします（低CPU環境向け）。
 - CSP はプレビューで外部 JS/CSS を使えるよう意図的に緩めています。信頼できる環境でのみ利用してください。
 - プレビュー iframe は same-origin を許可しているため、Cookie / localStorage / 認証付きAPIが動作します。
-- デフォルトでは Thymeleaflet は Spring Security のルールを自動登録しません。
-- Spring Security 利用アプリで設定を簡略化したい場合は `thymeleaflet.security.auto-permit=true` を設定すると、`/thymeleaflet/**` を許可する最小ルールを自動登録します。
-- 明示的に管理したい場合はデフォルトのままにして、利用側アプリの `SecurityFilterChain` で `/thymeleaflet/**` を許可してください。
+- デフォルトでは、Spring Security が存在する場合に `/thymeleaflet/**` を許可する最小ルールを自動登録します。
+- 明示的に管理したい場合は `thymeleaflet.security.auto-permit=false` を設定し、利用側アプリの `SecurityFilterChain` で `/thymeleaflet/**` を許可してください。
 
 ## エンドポイント
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ thymeleaflet:
 - `cache.preload` warms the caches at application startup (useful for low-CPU demo environments).
 - CSP is intentionally permissive to allow external JS/CSS in previews. Use only in trusted environments.
 - Preview iframes allow same-origin so cookies/localStorage and authenticated API calls work.
-- By default, Thymeleaflet does not register Spring Security rules.
-- If your app uses Spring Security and you want zero-config onboarding, set `thymeleaflet.security.auto-permit=true` to auto-register a minimal permit rule for `/thymeleaflet/**`.
-- If you prefer explicit control, keep the default and allow `/thymeleaflet/**` in your app-side `SecurityFilterChain`.
+- By default, Thymeleaflet auto-registers a minimal Spring Security permit rule for `/thymeleaflet/**` when Spring Security is present.
+- If you prefer explicit control, set `thymeleaflet.security.auto-permit=false` and allow `/thymeleaflet/**` in your app-side `SecurityFilterChain`.
 
 ## Endpoints
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -58,10 +58,11 @@ JavaScript を使いたい場合は `resources.scripts` に登録してくださ
 
 | プロパティ | 型 | デフォルト | 説明 |
 |---|---|---|---|
-| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: Spring Security 利用時に `/thymeleaflet/**` 許可の最小ルールを自動登録。開発時の quick start 用です |
+| `thymeleaflet.security.auto-permit` | boolean | `true` | Spring Security 利用時に `/thymeleaflet/**` 許可の最小ルールを自動登録。明示管理する場合は `false` にします |
 
 `prod` または `production` profile が有効な状態で Thymeleaflet UI も有効な場合、起動時に WARN を出します。
-さらに `thymeleaflet.security.auto-permit=true` の場合は、UI パスを許可する高リスク設定として追加の WARN を出します。
+さらに `thymeleaflet.security.auto-permit` が有効な場合は、UI パスを許可する高リスク設定として追加の WARN を出します。
+この補助設定は、明示的に `false` を指定しない限りデフォルトで有効です。
 
 ### CSP 補足（意図的に緩め）
 
@@ -70,10 +71,10 @@ Thymeleaflet はプレビューで外部 JS/CSS を使えるよう、CSP を意�
 
 ## Spring Security 連携
 
-デフォルトでは Thymeleaflet は独自の `SecurityFilterChain` を追加しません。
+デフォルトでは、Spring Security が存在する場合に `/thymeleaflet/**` 向けの小さな `SecurityFilterChain` を追加します。
 次のいずれかを選択してください:
 
-- 自動許可を Opt-in:
+- デフォルトの自動許可:
 
 ```yaml
 thymeleaflet:
@@ -81,7 +82,13 @@ thymeleaflet:
     auto-permit: true
 ```
 
-- 利用側アプリで明示的に設定:
+- Opt out して利用側アプリで明示的に設定:
+
+```yaml
+thymeleaflet:
+  security:
+    auto-permit: false
+```
 
 ```java
 http.authorizeHttpRequests(auth -> auth

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,12 +58,12 @@ parsing, type extraction, and dependency analysis reread source resources instea
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `thymeleaflet.security.auto-permit` | boolean | `false` | Opt-in: register minimal permit rule for `/thymeleaflet/**` when Spring Security is present. Use only for development quick starts |
+| `thymeleaflet.security.auto-permit` | boolean | `true` | Register a minimal permit rule for `/thymeleaflet/**` when Spring Security is present. Set `false` to opt out and manage app-side security explicitly |
 
 When a `prod` or `production` profile is active, Thymeleaflet logs a warning if
 the UI is still enabled. It logs an additional warning when
-`thymeleaflet.security.auto-permit=true` is also active because that setting
-permits the UI path.
+`thymeleaflet.security.auto-permit` is active because that setting permits the
+UI path. The helper is active by default unless explicitly set to `false`.
 
 ### CSP note (permissive by design)
 
@@ -73,10 +73,11 @@ behind authentication and use it only in trusted environments.
 
 ## Spring Security Integration
 
-By default, Thymeleaflet does not add its own `SecurityFilterChain`.
+By default, Thymeleaflet adds a small `SecurityFilterChain` for `/thymeleaflet/**`
+when Spring Security is present.
 Use one of the following options:
 
-- Opt-in auto permit:
+- Default auto permit:
 
 ```yaml
 thymeleaflet:
@@ -84,7 +85,13 @@ thymeleaflet:
     auto-permit: true
 ```
 
-- Explicit app-side security rule:
+- Opt out and use an explicit app-side security rule:
+
+```yaml
+thymeleaflet:
+  security:
+    auto-permit: false
+```
 
 ```java
 http.authorizeHttpRequests(auth -> auth

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -106,12 +106,13 @@ spring:
 
 本番ビルドから依存関係を外す運用でも問題ありません。
 `prod` または `production` profile で Thymeleaflet が有効な場合、起動時に WARN を出します。
-`thymeleaflet.security.auto-permit=true` の場合は UI パスを許可するため、追加の WARN を出します。
+`thymeleaflet.security.auto-permit` が有効な場合は UI パスを許可するため、追加の WARN を出します。
+この補助設定は、明示的に `false` を指定しない限りデフォルトで有効です。
 
 Spring Security を使う場合は、次のいずれかを選択してください。
 
-- 手早く使う: `thymeleaflet.security.auto-permit=true`
-- 明示管理: 利用側アプリのセキュリティ設定で `/thymeleaflet/**` を許可
+- 手早く使う: デフォルトの自動許可を利用する
+- 明示管理: `thymeleaflet.security.auto-permit=false` を設定し、利用側アプリのセキュリティ設定で `/thymeleaflet/**` を許可
 
 `thymeleaflet.base-path` は現在 `/thymeleaflet` のみサポートしています。
 別のパスを設定すると起動時にエラーになります。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,13 +106,13 @@ spring:
 
 Alternatively, remove the dependency from production builds. If Thymeleaflet is
 active under a `prod` or `production` profile, startup logs a warning.
-`thymeleaflet.security.auto-permit=true` logs an additional warning because it
-permits the UI path.
+`thymeleaflet.security.auto-permit` logs an additional warning because it permits
+the UI path. This helper is enabled by default unless set to `false`.
 
 If your app uses Spring Security, either:
 
-- set `thymeleaflet.security.auto-permit=true` for quick onboarding, or
-- permit `/thymeleaflet/**` in your app-side security configuration.
+- keep the default auto-permit helper for quick onboarding, or
+- set `thymeleaflet.security.auto-permit=false` and permit `/thymeleaflet/**` in your app-side security configuration.
 
 `thymeleaflet.base-path` currently supports only `/thymeleaflet`.
 Using another path fails fast at startup.

--- a/docs/security.ja.md
+++ b/docs/security.ja.md
@@ -1,14 +1,14 @@
 # セキュリティ
 
-Thymeleaflet は Spring Security のフィルターチェーンを自動登録しません。
+Spring Security が存在する場合、Thymeleaflet はデフォルトで `/thymeleaflet/**` を許可する最小限のフィルターチェーンを登録します。
 開発用途向けの補助ツールとして利用してください。
 
 ## 連携方針
 
 セキュリティ挙動は利用側アプリで管理します。
-Spring Security を使う場合は、Opt-in 自動許可か明示設定を選択できます。
+Spring Security を使う場合は、デフォルトの自動許可を使うか、opt out して明示設定できます。
 
-### Option A: Opt-in 自動許可（手早く使う）
+### Option A: デフォルトの自動許可（手早く使う）
 
 ```yaml
 thymeleaflet:
@@ -18,9 +18,16 @@ thymeleaflet:
 
 この設定で `/thymeleaflet/**` のみを許可する最小チェーンを登録します。
 ローカル開発または信頼できる内部環境向けの quick start として扱ってください。
-`prod` または `production` profile で `auto-permit=true` が有効な場合、起動時に WARN を出します。
+`prod` または `production` profile で `auto-permit` が有効な場合、起動時に WARN を出します。
+この補助設定は、明示的に `false` を指定しない限りデフォルトで有効です。
 
-### Option B: 利用側で明示設定
+### Option B: Opt out して利用側で明示設定
+
+```yaml
+thymeleaflet:
+  security:
+    auto-permit: false
+```
 
 ```java
 http.authorizeHttpRequests(auth -> auth
@@ -31,10 +38,11 @@ http.authorizeHttpRequests(auth -> auth
 
 ## 挙動
 
-- Thymeleaflet 自体は認可/認証ルールを追加しません。
-- Thymeleaflet 自体は CSRF/ヘッダー/セッション制御を追加しません。
+- 自動許可ヘルパーは `/thymeleaflet/**` の認可だけを追加します。
+- 自動許可ヘルパーは、Custom story の POST レンダリングが動作するよう Thymeleaflet UI パスの CSRF を無効化します。
+- Thymeleaflet はヘッダー/セッション制御を追加しません。
 - 既存アプリのセキュリティ設定がそのまま有効です。
-- `auto-permit=true` の場合のみ、`/thymeleaflet/**` 向けの最小許可チェーンを追加します。
+- `auto-permit=false` の場合、Thymeleaflet は `SecurityFilterChain` を追加しません。
 
 ## 推奨
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,14 +1,16 @@
 # Security
 
-Thymeleaflet does not register a Spring Security filter chain.
+When Spring Security is present, Thymeleaflet registers a minimal permit filter
+chain for `/thymeleaflet/**` by default.
 This tool is intended for development use.
 
 ## Integration Policy
 
 Security behavior is owned by the host application.
-If your app uses Spring Security, you can either use opt-in auto-permit or configure the rule yourself.
+If your app uses Spring Security, you can either use the default auto-permit helper
+or opt out and configure the rule yourself.
 
-### Option A: Opt-in auto permit (quick start)
+### Option A: Default auto permit (quick start)
 
 ```yaml
 thymeleaflet:
@@ -19,9 +21,15 @@ thymeleaflet:
 This registers a minimal chain for `/thymeleaflet/**` only.
 Use this only for local development or trusted internal environments. If a
 `prod` or `production` profile is active, Thymeleaflet logs a warning when
-`auto-permit=true` is enabled.
+`auto-permit` is enabled. This helper is enabled by default unless set to `false`.
 
-### Option B: App-side explicit rule
+### Option B: Opt out and use an app-side explicit rule
+
+```yaml
+thymeleaflet:
+  security:
+    auto-permit: false
+```
 
 ```java
 http.authorizeHttpRequests(auth -> auth
@@ -32,10 +40,11 @@ http.authorizeHttpRequests(auth -> auth
 
 ## Behavior
 
-- Thymeleaflet adds no authentication/authorization rules.
-- Thymeleaflet adds no CSRF/header/session rules.
+- The auto-permit helper adds only `/thymeleaflet/**` authorization.
+- The auto-permit helper disables CSRF for the Thymeleaflet UI path so custom story POST rendering works.
+- Thymeleaflet adds no header or session rules.
 - Existing app security configuration remains authoritative.
-- If `auto-permit=true`, Thymeleaflet adds only a minimal `/thymeleaflet/**` permit chain.
+- If `auto-permit=false`, Thymeleaflet adds no `SecurityFilterChain`.
 
 ## Recommendations
 

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnostics.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnostics.java
@@ -44,7 +44,7 @@ public class ProductionExposureDiagnostics implements ApplicationRunner {
         );
         if (storybookConfig.getSecurity().isAutoPermit()) {
             warnings.add(
-                "thymeleaflet.security.auto-permit=true is active under a production profile and permits "
+                "thymeleaflet.security.auto-permit is active under a production profile and permits "
                     + storybookConfig.getBasePath() + "/**. Prefer app-owned authentication rules or disable "
                     + "Thymeleaflet in production."
             );

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookProperties.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookProperties.java
@@ -254,9 +254,9 @@ public class StorybookProperties {
     public static class SecurityConfig {
         /**
          * true のとき `/thymeleaflet/**` を許可する補助チェーンを登録する
-         * デフォルト: false
+         * デフォルト: true
          */
-        private boolean autoPermit = false;
+        private boolean autoPermit = true;
 
         public boolean isAutoPermit() {
             return autoPermit;

--- a/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ThymeleafletAutoPermitSecurityConfig.java
+++ b/src/main/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ThymeleafletAutoPermitSecurityConfig.java
@@ -13,7 +13,7 @@ import org.springframework.security.web.SecurityFilterChain;
 /**
  * Optional Spring Security integration for quick adoption.
  *
- * <p>When {@code thymeleaflet.security.auto-permit=true}, this registers
+ * <p>Unless {@code thymeleaflet.security.auto-permit=false}, this registers
  * a small filter chain that permits only {@code /thymeleaflet/**}.</p>
  */
 @Configuration
@@ -21,7 +21,7 @@ import org.springframework.security.web.SecurityFilterChain;
     "org.springframework.security.web.SecurityFilterChain",
     "org.springframework.security.config.annotation.web.builders.HttpSecurity"
 })
-@ConditionalOnProperty(name = "thymeleaflet.security.auto-permit", havingValue = "true")
+@ConditionalOnProperty(name = "thymeleaflet.security.auto-permit", havingValue = "true", matchIfMissing = true)
 public class ThymeleafletAutoPermitSecurityConfig {
 
     private final String basePath;

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -108,8 +108,8 @@
     {
       "name": "thymeleaflet.security.auto-permit",
       "type": "java.lang.Boolean",
-      "description": "When true, registers a minimal SecurityFilterChain to permit /thymeleaflet/**. Intended for development quick starts; avoid in production.",
-      "defaultValue": false
+      "description": "When true, registers a minimal SecurityFilterChain to permit /thymeleaflet/**. Enabled by default for development quick starts; set false to opt out.",
+      "defaultValue": true
     }
   ]
 }

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnosticsTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ProductionExposureDiagnosticsTest.java
@@ -27,9 +27,23 @@ class ProductionExposureDiagnosticsTest {
     void warningMessages_shouldWarnWhenAutoPermitIsActiveUnderProductionProfile() {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("production");
+
+        List<String> warnings = ProductionExposureDiagnostics.warningMessages(
+            environment,
+            ResolvedStorybookConfig.from(new StorybookProperties())
+        );
+
+        assertThat(warnings)
+            .anyMatch(message -> message.contains("thymeleaflet.security.auto-permit is active"));
+    }
+
+    @Test
+    void warningMessages_shouldNotWarnAboutAutoPermitWhenOptedOutUnderProductionProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("production");
         StorybookProperties properties = new StorybookProperties();
         StorybookProperties.SecurityConfig security = new StorybookProperties.SecurityConfig();
-        security.setAutoPermit(true);
+        security.setAutoPermit(false);
         properties.setSecurity(security);
 
         List<String> warnings = ProductionExposureDiagnostics.warningMessages(
@@ -38,7 +52,7 @@ class ProductionExposureDiagnosticsTest {
         );
 
         assertThat(warnings)
-            .anyMatch(message -> message.contains("thymeleaflet.security.auto-permit=true"));
+            .noneMatch(message -> message.contains("thymeleaflet.security.auto-permit is active"));
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfigTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/ResolvedStorybookConfigTest.java
@@ -24,19 +24,19 @@ class ResolvedStorybookConfigTest {
         assertThat(resolved.getResources().getTemplatePaths()).containsExactly("/templates/");
         assertThat(resolved.getPreview().getBackgroundLight()).isEqualTo("#f3f4f6");
         assertThat(resolved.getPreview().getBackgroundDark()).isEqualTo("#1f2937");
-        assertThat(resolved.getSecurity().isAutoPermit()).isFalse();
+        assertThat(resolved.getSecurity().isAutoPermit()).isTrue();
     }
 
     @Test
-    void from_resolvesSecurityAutoPermitFlag() {
+    void from_resolvesSecurityAutoPermitOptOutFlag() {
         StorybookProperties raw = new StorybookProperties();
         StorybookProperties.SecurityConfig security = new StorybookProperties.SecurityConfig();
-        security.setAutoPermit(true);
+        security.setAutoPermit(false);
         raw.setSecurity(security);
 
         ResolvedStorybookConfig resolved = ResolvedStorybookConfig.from(raw);
 
-        assertThat(resolved.getSecurity().isAutoPermit()).isTrue();
+        assertThat(resolved.getSecurity().isAutoPermit()).isFalse();
     }
 
     @Test

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookAutoConfigurationTest.java
@@ -63,6 +63,16 @@ class StorybookAutoConfigurationTest {
     }
 
     @Test
+    void autoPermitSecurityConfiguration_shouldBeEnabledWhenPropertyIsMissing() {
+        ConditionalOnProperty annotation = ThymeleafletAutoPermitSecurityConfig.class.getAnnotation(ConditionalOnProperty.class);
+
+        assertNotNull(annotation, "auto-permit security configuration should be property-gated");
+        assertEquals("thymeleaflet.security.auto-permit", annotation.name()[0]);
+        assertEquals("true", annotation.havingValue());
+        assertTrue(annotation.matchIfMissing(), "auto-permit should be enabled by default and opt-out with false");
+    }
+
+    @Test
     void thymeleafletObjectMapperBean_shouldBeConditionalOnMissingBean() throws NoSuchMethodException {
         Method method = StorybookAutoConfiguration.class.getDeclaredMethod("thymeleafletObjectMapper");
         ConditionalOnMissingBean annotation = method.getAnnotation(ConditionalOnMissingBean.class);

--- a/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookPropertiesTest.java
+++ b/src/test/java/io/github/wamukat/thymeleaflet/infrastructure/configuration/StorybookPropertiesTest.java
@@ -44,9 +44,12 @@ class StorybookPropertiesTest {
     @Test
     void rawSecurityConfig_acceptsBooleanToggle() {
         StorybookProperties.SecurityConfig security = new StorybookProperties.SecurityConfig();
-        security.setAutoPermit(true);
 
         assertThat(security.isAutoPermit()).isTrue();
+
+        security.setAutoPermit(false);
+
+        assertThat(security.isAutoPermit()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Enable `thymeleaflet.security.auto-permit` by default when Spring Security is present.
- Preserve opt-out behavior with `thymeleaflet.security.auto-permit=false`.
- Update configuration/security docs, metadata, and production diagnostics wording.

## Verification

- `./mvnw -Dtest=ResolvedStorybookConfigTest,StorybookAutoConfigurationTest,StorybookPropertiesTest,ProductionExposureDiagnosticsTest,ConfigurationMetadataCoverageTest test`
- `./mvnw test -q`
- `npm run test:e2e:local`
- Sub-agent review: no findings

Closes #190
