### PR TITLE
Prepare release 0.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project follows the Keep a Changelog format and uses Semantic Versioning.
 - Added
   - TBD
 
+## [0.2.28] - 2026-05-06
+
+- Changed
+  - Enabled `thymeleaflet.security.auto-permit` by default when Spring Security is present, so zero-config apps can use custom story POST rendering without a CSRF 403. Set `thymeleaflet.security.auto-permit=false` to opt out and manage security explicitly. (#190)
+- Docs
+  - Updated README, configuration, getting-started, security, and Spring configuration metadata docs to describe the new opt-out security helper behavior. (#190)
+- Test
+  - Added configuration, metadata, and production diagnostic coverage for the default-enabled auto-permit behavior and explicit opt-out path. (#190)
+- Build
+  - Updated Maven project, sample app, and README dependency examples to `0.2.28`.
+
+### Issues
+
+- #190 `thymeleaflet.security.auto-permit` default should be true
+
 ## [0.2.27] - 2026-05-06
 
 - Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.27</version>
+  <version>0.2.28</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.27")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.28")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>io.github.wamukat</groupId>
   <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-  <version>0.2.27</version>
+  <version>0.2.28</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.27")
+    implementation("io.github.wamukat:thymeleaflet-spring-boot-starter:0.2.28")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat</groupId>
     <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-    <version>0.2.27</version>
+    <version>0.2.28</version>
     <packaging>jar</packaging>
 
     <name>Thymeleaflet Spring Boot Starter</name>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wamukat.thymeleaflet.samples</groupId>
     <artifactId>thymeleaflet-sample</artifactId>
-    <version>0.2.27</version>
+    <version>0.2.28</version>
 
     <name>Thymeleaflet Sample</name>
     <description>Sample app for thymeleaflet-spring-boot-starter</description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.github.wamukat</groupId>
             <artifactId>thymeleaflet-spring-boot-starter</artifactId>
-            <version>0.2.27</version>
+            <version>0.2.28</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

- Prepare release `0.2.28`.
- Update root/sample Maven versions and README dependency examples.
- Update `CHANGELOG.md` with GH#190 user-facing release notes.

## Verification

- `./mvnw test -q`
- `npm run test:e2e:local`
- Confirmed no process remains listening on port `6006`.

Closes: N/A
